### PR TITLE
Kelly's work on schema-parsing + scope and state mgm bug fixes + commitMutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ dist
 # react-relay-app 
 # /react-relay-app/vanilla-gql-example.js
 react-relay-app/__generated__
+./draft.js

--- a/PeriqlesForm.jsx
+++ b/PeriqlesForm.jsx
@@ -1,49 +1,145 @@
 import React, {useState} from 'react';
-import commitMutation from 'react-relay'; // importing the mutation commit fn provided by Relay instead of expecting mutation prop to have a commit() method with params of a certain shape
+import {commitMutation, graphql} from 'react-relay';
+// importing the mutation commit fn provided by Relay instead of expecting mutation prop to have a commit() method with params of a certain shape
 
 /**
  * Wraps the PeriqlesForm component in a closure containing the Relay project's schema and RelayEnvironment.
- * @param {Object} Schema (REQUIRED) The graphQL schema used in this application  
- * @param {Object} Environment (REQUIRED) - The environment variable for this application containing the network layer and store
- * @return {Function} Returns an inner function PeriqlesForm? that generates a Periqles React form component 
+ * @param {Object} schema (REQUIRED) The GraphQL schema used in this application, provided implicitly by periqles.introspect().  
+ * @param {Object} environment (REQUIRED) The environment variable for this application, containing the network layer and store. Provided implicitly by periqles.introspect(). 
+ * @return {Function} PeriqlesForm, a React functional component
  * 
  */
  export default function periqlesFormWrapper (schema, environment){
 
+  // TODO: use the options property added to enumerated fields
+  const fieldsArrayGenerator = (mutationName, args) => {
+  const fieldsArray = [];
+  // exclude from the form any inputs accounted for by args
+  const exclude = args.map((arg) => arg.name);
+  const inputName = mutationName + 'Input';
+  // console.log('Generating field objects for this input type:', inputName);
+  let inputObj = schema[inputName];
+
+  inputObj.inputFields.forEach((inputField) => {
+    // console.log('Current input field:', inputField);
+    if (exclude.includes(inputField.name)) return;
+    
+    if(inputField.type.name === null) {
+        // if field type name is null, this field may be a sub-field of another type. Iterate over the types in the schema to find it.
+        Object.keys(schema).forEach(key => {
+          // console.log('Currently checking this type:', key, schema[key]);
+            // At each type, check if it has a fields array including this field's name.
+            if (!schema[key].fields) { 
+              // console.log(`Schema type ${key} has no fields -- returning.`);
+              return; 
+            }
+            // error: inputField.name is a string, but fields is an array of objects
+            // if (!schema[key].fields.includes(inputField.name)) {console.log(`Schema type ${key} has fields, but none matching '${inputField.name}'.`);return;}
+
+            schema[key].fields.forEach((field) => { 
+                // console.log('current field name: ', field.name);
+                if (field.name !== inputField.name) return;
+  
+                if (field.type.ofType.kind === 'SCALAR'){
+                    // console.log('This field is a scalar field:', field.name);
+
+                    const fieldObj = {};
+                    fieldObj.name = field.name;
+                    fieldObj.type = field.type.ofType.name;
+                    fieldsArray.push(fieldObj);
+                    return;
+                    // inputField.type.name = field.type.ofType.name
+
+                } else if(field.type.kind === 'ENUM') {
+                    // console.log('This field is an enumerated field:', field.name);
+                    const fieldObj = {
+                        name: field.name,
+                        type: 'Enum',
+                        options: {}
+                    };
+
+                    // TODO: Populate fieldObj.options. Check out inputFields and other properties of __EnumValue type on schema.
+                    /*
+                    allTypes.forEach((type)=>{
+                        if (field.type.name === type.name) {
+                            fieldObj.options = type.enumValues.name; //expecting this to be an object
+                        }
+                    });
+                    */
+
+                    fieldsArray.push(fieldObj);
+                    return;
+                } else {
+                    console.warn('inputField', inputField.name, 'matches a subfield of the', key, 'schema type, but it is not a scalar or enum type. This field\'s type is:', field.type, '. Defaulting to string.');  
+                    const fieldObj = {
+                      name: field.name,
+                      type: 'String',
+                    };
+                    fieldsArray.push(fieldObj);
+                    return;
+                }
+            });
+        }); 
+    }      
+    /*
+    } else if (inputField.type.kind == 'OBJECT' || inputField.type.name.type !== null) {
+        // TODO: What if input field is not scalar or enum but an object type? E.g., the "todos" field on User is of type TodoConnection. May require a recursive solution because types could be composed of arbitrarily nested objects.
+        console.warn('inputField', inputField.name, 'is an object type:', field.type.name, '. Assigning it a placeholder type for now.');     
+    } 
+    */
+    // input field type is not null, ie, scalar
+    else {
+        // console.log('This field\'s type is not null:', inputField)
+        let fieldObj = {
+          name: inputField.name,
+          type: inputField.type.name,
+        };
+        fieldsArray.push(fieldObj);
+        return; 
+    }
+  });
+
+  return fieldsArray;
+}
+
+
   /**
    * A React functional component with input fields corresponding to a Relay mutation.
-   * @param {String} mutationName (REQUIRED) The name of a mutation as written on the Relay schema.
+   * @param {String} mutationName (REQUIRED) The name of a mutation axactly s written on the Relay schema.
    * @param {String} mutationGQL (REQUIRED) The GraphQL query string representing the mutation.
    * @param {Object} specifications Optional parameters to specify the form's elements. 
    * @param {[Object]} args Optional input values for the mutation, represented as objects with the shape {[nameOfInputField]: value}. Input fields represented here will not be represented on the form.
    * @return HTML
    */
+
   const PeriqlesForm = ({mutationName, mutationGQL, specifications, args}) => {  
-    // console.log('PeriqlesForm component successfully imported');
     // console.log('PeriqlesForm is using this schema: ', schema);
+    console.log('PeriqlesForm will exclude these args:', args);
+
     // STATE  
     const formState = {};   //--> { fieldName: { value: valueOfState, set: fnToSetState }};
-
-    // mock fields array
-    const fields = [{name: 'name', type: 'string'}, {name:'age', type:'number'}, {name:'gender', type:'string'}, {name:'over18', type:'boolean'}];
-
+    
+    // distill input fields from mutation schema
+    const fields = fieldsArrayGenerator(mutationName, args);
+    console.log('Generated input fields array:', fields);   // TODO: why does AddTodoInput generate a field object for the 'text' field that has a label of 'Text'?
+    // assign an initial state for each field that reflects its data type (called 'element')
     fields.forEach((field) => {
       // console.log('field object', field);
       let initialValue;
       switch (field.type) {
-        case 'string': 
+        case 'String': 
           initialValue = '';
           break;
-        case 'number':
+        case 'Int':
           initialValue = 0;
           break;
-        case 'boolean':
+        case 'Boolean':
           initialValue = false;
           break;
         default:
-          initialValue = null;
+          initialValue = '';
       }
-      // Assign a piece of state and a setter function for each field
+      // Declare a piece of state and a setter function for each field
       const [value, set] = useState(initialValue);   
       formState[field.name] = {              
         value,
@@ -51,6 +147,7 @@ import commitMutation from 'react-relay'; // importing the mutation commit fn pr
       };
     });
     
+    // console.log('commitMutation:', commitMutation);
     
     // HANDLERS
     /**
@@ -61,29 +158,30 @@ import commitMutation from 'react-relay'; // importing the mutation commit fn pr
         e.preventDefault();   // prevent page refesh 
       }
       
-      // populate $input for mutation
       const input = {
-        clientMutationId,      // TODO: How to get this in scope? Is this needed for every commit?
+        // clientMutationId,      // TODO: Can we arbitrarily assign this like they do in js/mutations/AddTodoMutation.js?
       };
       Object.keys(formState).forEach(key => {
         input[key] = formState[key].value;
       });
       if (args) {
-        args.forEach(([key, value]) => {
-          input[key] = value;
+        args.forEach(({name, value}) => {
+          input[name] = value;
         });
       }
-  
+
+      console.log(mutationGQL);
+
       // Documentation re: shape of commitMutation's second parameter: https://relay.dev/docs/en/mutations#arguments
       // Referencing use of commitMutation in js/mutations/AddTodoMutation
       const variables = {
         input,
       };
       commitMutation(environment, {
-        mutationString,       // --> MUST BE A QUERY STRING
+        mutation: mutationGQL,
         variables,
         onCompleted: (response, errors) => console.log('Server response to mutation:', response, errors),
-        onError: (err) => console.error(err)
+        onError: (err) => console.error('Problem committing mutation:', err),
       });   
     }
       
@@ -96,207 +194,286 @@ import commitMutation from 'react-relay'; // importing the mutation commit fn pr
       formState[name].set(value);
       // console.log('new state:', formState);
     }
-  
+
+    // HELPER FUNCTIONS
     /**
-     * Builds a HTML form based on user provided parameters
-     * @param {String} mutation (REQUIRED) The name of the graphQL mutation used for the form. Example: 'addTodo'
-     * @param {Object} specifications (OPTIONAL) - an object containing fields to use with the form. Example: {fields: [{name: "name", element: "text", id: "textID"}]}
-     * @return  Returns a React Component with the generated form 
+     * Builds an HTML element to collect user input for a GraphQL mutation based on user-provided instructions.
+     * @param {Object} input An object representing an input field for a GraphQL mutation. Example: {name: "name", type: "String"}
+     * @param {Object} specs An object representing developer-specified information to use for an HTML element representing this field. Example: {label: "Name", element: "textarea", options: []}
+     * @return  Returns the specified HTML input element with the specified label and specified sub-options, if any.
      * 
      */
-    const formBuilder = () => {
-      const formElements = [];
-      // iterate through specifications to get form fields order & mutation inputs
-      specifications.fields.forEach((input) => {
-        let element;
-        switch (input.element) {
-          case 'range':
-            element = 
+    const generateSpecifiedElement = (input) => {     
+      let element;
+      switch (specs.element) {
+        case 'range':
+          element = 
               <label>
-                {input.name}
-                  <input type = {input.element} 
-                    class = {input.name + '-range periqles-range'} 
-                    name = {input.name} 
-                    min = {input.min} max ={input.max}
-                    value={formState[input.name].value} 
-                    onChange={handleChange}
-                />
+              {specs.label}
+              <input type="range"
+                  className={input.name + '-range periqles-range'} 
+                  name={input.name} 
+                  min={specs.min || 0} max={specs.max || Infinity}   
+                  value={formState[input.name].value} 
+                  onChange={handleChange}
+              />
               </label>
-            break;
-          case 'image':
-            element = 
+              // note: dev may or may not include min and max values in specs; need fallback values to prevent throwing an error
+          break;
+        case 'image':
+          element = 
               <label>
-                {input.name}
-                  <input type = {input.element} 
-                      className = {input.name + '-image periqles-image'}
-                      name = {input.name} 
-                      src = {input.src} alt = {input.name} 
+              {specs.label}
+                  <input type="image"
+                      className ={input.name + '-image periqles-image'}
+                      name={input.name} 
+                      src={specs.src} alt={specs.label} 
                       value={formState[input.name].value} 
                       onChange={handleChange}
                   />
               </label>
-            break;
-          // TODO: how to handle state of radio buttons?
-          case 'radio':
-            const radioOptions = [];
-            input.options.forEach((radio) => {
+          break;
+        // TODO: how to handle state and value of radio buttons?
+        case 'radio':
+          const radioOptions = [];
+          specs.options.forEach((radio) => {
               const radioInput = 
-                <label>
-                  <input 
-                    type="radio" 
-                    className={input.name + '-radio-option periqles-radio-option'} 
-                    name={input.name} 
-                    value={radio.value}/>   
-                </label>;
+                  <label>
+                      <input 
+                          type="radio" 
+                          name={input.name} 
+                          className={input.name + '-radio-option periqles-radio-option'}
+                          value={radio.value} 
+                          />
+                      {specs.label}   
+                  </label>;
               radioOptions.push(radioInput);
-            })
-            element = 
-              <div className={input.name + '-radio periqles-radio'}>
-                {radioOptions}
+          })
+          element = 
+              <div className={input.name + '-radio periqles-radio'}
+                  value={formState[input.name].value}
+                  onChange={handleChange}>
+              {radioOptions}
               </div>
-            break;
-          // TODO: handle non-null/non-null-default dropdowns
-          case 'dropdown':
+          break;
+        // TODO: handle non-null/non-null-default dropdowns
+        case 'dropdown':
             const selectOptions = [];
             selectOptions.push(
-              <option 
-                value={null} 
-                className={input.name + '-select-option periqles-select-option'} 
-                selected>
-                  {input.name}
-              </option>);
-            input.options.forEach((option) => {
-              selectOptions.push(
                 <option 
-                  value={option.value} 
-                  className={input.name + '-select-option periqles-select-option'}
-                  >
-                    {option.name}
+                    value={''} 
+                    className={input.name + '-select-option periqles-select-option'} 
+                    selected
+                >
+                {specs.label}
+                </option>);
+            specs.options.forEach((option) => {
+                selectOptions.push(
+                <option 
+                    value={option.value} 
+                    className={input.name + '-select-option periqles-select-option'}
+                    >
+                    {option.label}
                 </option>)
             })
             element = 
+                <select 
+                    className={input.name + '-select periqles-select'} 
+                    name={input.name}
+                    defaultValue={''} 
+                    onChange={handleChange}
+                >
+                {selectOptions}
+                </select>;
+            break;
+        case 'textarea':
+            element = 
+                <label>{specs.label}
+                    <textarea 
+                        className={input.name + '-textarea periqles-textarea'} 
+                        name={input.name}
+                        value={formState[input.name].value} 
+                        onChange={handleChange}
+                    />
+                </label>; 
+            break;
+        default:
+            element = 
+                <label>{specs.label}
+                    <input 
+                        type="text"
+                        className={input.name + '-input periqles-text'} 
+                        name={input.name} 
+                        value={formState[input.name].value} 
+                        onChange={handleChange}>
+                    </input>
+                </label>
+      }
+  
+      return element;
+    }
+
+    const generateDefaultElement = (fieldObj) => {
+      // assign a label that matches name but w/ spaces between words and first char uppercased
+      fieldObj.label = fieldObj.name.replace(/([a-z])([A-Z])/g, '$1 $2') 
+      fieldObj.label = fieldObj.label[0].toUpperCase() + fieldObj.label.slice(1);
+      
+      let element;
+
+      switch (fieldObj.type){
+        case 'Int':
+          element =
+            <label>{fieldObj.label}
+              <input 
+                type='number'
+                className={fieldObj.name + '-number periqles-number'} 
+                name={fieldObj.name} 
+                value={formState[fieldObj.name].value}
+                onChange={handleChange}>
+              </input>
+            </label>;
+            break;
+          
+        case 'Boolean':
+          element =
+            <label>{fieldObj.label}
+              <input 
+                type="checkbox"
+                className={fieldObj.name + '-checkbox periqles-checkbox'}
+                name={fieldObj.name}
+                value={formState[fieldObj.name].value}
+                onChange={handleChange}>
+              </input>
+            </label>;
+            break;
+
+        case 'Enum':
+          const optionsObj = fieldObj.options;
+          const selectOptions = [];
+          // default value displays label of field
+          selectOptions.push(
+            <option 
+                value={''} 
+                className={input.name + '-select-option periqles-select-option'} 
+                selected
+            >
+            {specs.label}
+            </option>);
+          //iterate through the options for the field & make a tag for each option
+          // TODO: check shape of options collection
+          for (const option in optionsObj){
+            selectOptions.push(
+              <option 
+                value={option.value} 
+                className={option + '-select-option'} 
+              >
+                {option}
+              </option>
+            );
+          }
+          
+          element = 
+            <label>{fieldObj.label}
               <select 
-                className={input.name + '-select periqles-select'} 
-                name={input.name}
-                defaultValue={null} 
+                className={fieldObj.name+ '-select'} 
+                name={fieldObj.name}
+                defaultValue={''} 
                 onChange={handleChange}
                 >
                   {selectOptions}
-              </select>;
-            break;
-          case 'textarea':
+              </select>
+            </label>;
+          break;
+        default:
             element = 
-              <label>{input.name}
-                <textarea 
-                  className={input.name + '-textarea periqles-textarea'} 
-                  name={input.name}
-                  placeholder={input.name}
-                  value={formState[input.name].value} 
-                  onChange={handleChange}
-                  />
-              </label>; 
-            break;
-          default:
-            element = 
-              <label>{input.name}
+              <label>{fieldObj.label}
                 <input 
-                  type={input.element || 'text'}
-                  className={input.name + '-input periqles-text'} 
-                  name={input.name} 
-                  value={formState[input.name].value} 
-                  placeholder={input.name}
+                  type='text'
+                  className={fieldObj.name + '-input periqles-text'}
+                  name={fieldObj.name} 
+                  value={formState[fieldObj.name].value}
                   onChange={handleChange}>
                 </input>
-              </label>
-        }
-  
-        formElements.push(element);
-      });
-  
-      return formElements;
+              </label>;
+              break; 
+
+      }
+
+      return(element);
     }
-  
+
+
+    /**
+     * By referencing the name of a mutation on a GraphQL schema, generates an HTML element for each field where user input is required. Assumes that if the mutation name takes the form of "<description>Mutation", its corresponding input type will be named "<description>Input".
+     * @param {Array} fieldsArray An array of objects representing the names and data types of input fields, deduced from an input type on the GraphQL schema.
+     * @param {string} mutationName The name of a GraphQL mutation exactly as it appears on the schema.
+     * @param {object} specifications
+     * @param {object} args An object whose keys represent the names of mutation input fields to exclude from the form, and whose values provide the value to be used for each variable when the mutation is committed. 
+     */
+
+    const formBuilder = (fields) => {
+      const formElementsArray = [];
+      //const fieldsArray = fieldsArrayGenerator(mutationName, schema);
+      fields.forEach((fieldObj) => {
+        if(args[fieldObj.name]) return;     // early return 
+
+        let element;
+        if(specifications.fields[fieldObj.name]){
+          element = generateSpecifiedElement(fieldObj, specifications.fields[fieldObj.name]);
+        } else {
+          element = generateDefaultElement(fieldObj);
+        }
+        formElementsArray.push(element);           
+      });
+      return formElementsArray;
+    }
+
+    // ADDITIONAL ELEMENTS AND STYLES
+    let headerText = mutationName.replace('Mutation', '')                  
+                                  .replace(/([a-z])([A-Z])/g, '$1 $2');  // add spaces before capital letters
+    headerText = headerText[0].toUpperCase() + headerText.slice(1);        // capitalize first letter                                
+    
     return (
-      <form className="PeriqlesForm"
-            onSubmit={handleSubmit}>
-        {formBuilder()}
-        <button onClick={handleSubmit}>Submit</button>
-      </form>
+        // TODO: Add a handler to div to permit submitting with an "enter" keydown event anywhere inside the div
+        <div className="PeriqlesForm"
+            aria-labelledby= "form">
+            <h2>{headerText}</h2>
+            {formBuilder(fields)}
+            <button onClick={handleSubmit}>Submit</button>
+        </div>
     )
+    
   }
-  
+    
   return PeriqlesForm;
 }
 
+
 /*
 // mock props
-const schema = [{name: 'name', type: 'String'}];
+  const schema = {name: {name: 'name', type: 'String'}};
 const environment = {'networkLayer': 'fake network layer', 'store': 'fake Relay store'};
-const mutation = '';
+const mutation = 'AddTodoMutation';
+const mutationGQL = `mutation AddTodoMutation($input: AddTodoInput) { }`
 const specifications = {
-  fields: [
-    {
-      name: "name",
-      element: "text",
-      id: "textId",
+    fields: {
+        name: {
+            label: "Name",
+            element: "text",
+        },
+        gender: {
+            label: "Gender",
+            element: "radio",
+            options: [
+              {label: "male", value: "m"},
+              {label:"female", value: "f"},
+              {label: "non-binary", value: "x"},
+            ],
+        }
     },
-    {
-      name: "gender",
-      element: "radio",
-      options: [
-        {name: "male", value: "m"},
-        {name:"female", value: "f"},
-        {name: "prefer not to say", value: "x"},
-    }
-  ],
 };
 */
 
-// mock fields array
-    // const fields = [{name: 'name', type: 'string'}, {name:'age', type:'number'}, {name:'gender', type:'string'}, {name:'over18', type:'boolean'}];
-    /*
-    // define an initial state for the form, with the field name as the keys and their initial value as the values
-    const initialState = {};
-    fields.forEach(field => {
-      switch (field.type) {
-        case 'string': 
-          initialState[field.name] = '';
-          break;
-        case 'number':
-          initialState[field.name] = 0;
-          break;
-        case 'boolean':
-          initialState[field.name] = false;
-          break;
-        default:
-          initialState[field.name] = null;
-      }
-    })
-    const [formState, setFormState] = useState(initialState);
-    */
-
-
-//import schema, environment
-
-// import the schema response
-// parse through the response body to find the query/mutation & fields passed in as props
-// store the relevant data (types & inputs) in a variable
-
-  // is there linked data between different graphql objects?
-
-  // structure form elements in order equal to form structure props, if using custom form
-    // each form element must have corresponding event handler to store form values in local state
-    // create unique variables and/or hooks per form element?
-
-  // if no custom form fields supplied, check mutation types/inputs to determine default form input type
-    // write if logic to check each input type and build corresponding form HTML element
-    // each form element must have corresponding event handler to store form values in local state
-    // create unique variables and/or hooks per form element?
-
-  // validate user entered data against mutation required input types
-  // create event handlers to invoke mutation commit method on user submit
-    // handled in a submit button
-    // are all mutation commit methods structured the same?
   
 
   /*FORM VAILDATION NOTES:
@@ -305,4 +482,3 @@ const specifications = {
       -required tag: eg. <input type="text" id="username" name="username" required></input>
       -input type tell can specify a pattern: <input type="tel" id="phone" name="phone" placeholder="123-45-678" pattern="[0-9]{3}-[0-9]{2}-[0-9]{3}" required></input>
         */
-  

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ const introspect = (RelayEnvironment) => {
   .then(res => res.json())
   .then(({data}) => {
     schema = data.__schema.types || [];
-    console.log('Schema: ', schema);
+    // console.log('Schema: ', schema);
 
     if (!schema.length) {
       throw new Error('ERROR at periqles.introspect: Schema contains no types');

--- a/index.js
+++ b/index.js
@@ -21,8 +21,6 @@ import periqlesFormWrapper from './PeriqlesForm.jsx';
 
 
 const introspect = (RelayEnvironment) => {
-  let schema;   // array of type objects found in introspection
-
   const introspectionQuery = `{
     __schema {
         types {
@@ -41,6 +39,14 @@ const introspect = (RelayEnvironment) => {
           kind
           inputFields{
             name
+            type {
+              name
+              kind
+              ofType {
+                name
+                kind
+              }
+            }
           }
           ofType {
               name
@@ -60,19 +66,23 @@ const introspect = (RelayEnvironment) => {
       query: introspectionQuery,
     })
   })
-  .then(res => res.json())
-  .then(({data}) => {
-    schema = data.__schema.types || [];
-    // console.log('Schema: ', schema);
+    .then(res => res.json())
+    .then(({data}) => {
+      const typesArray = data.__schema.types || [];
+      if (!typesArray.length) {
+        throw new Error('ERROR at periqles.introspect: Schema contains no types');
+      }
 
-    if (!schema.length) {
-      throw new Error('ERROR at periqles.introspect: Schema contains no types');
-    }
+      // convert schema from array to object for faster lookup times within PeriqlesForm
+      const schema = {};
+      typesArray.forEach(type => {
+        schema[type.name] = type;
+      });
 
-    // Make our PeriqlesForm component available as a method on periqles with access to schema and environment.
-    PeriqlesForm = periqlesFormWrapper(schema, RelayEnvironment);
-  })  
-  .catch(err => console.error('ERROR at periqles.introspect:', err));
+      // Make our PeriqlesForm component available as a method on periqles with access to schema and environment.
+      PeriqlesForm = periqlesFormWrapper(schema, RelayEnvironment);
+    })  
+    .catch(err => console.error('ERROR at periqles.introspect:', err));
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/preset-react": "^7.12.7",
     "jest": "^23.6.0",
     "ts-loader": "^8.0.14",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.3",
     "eslint": "^7.14.0",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",

--- a/todo/data/schema.graphql
+++ b/todo/data/schema.graphql
@@ -1,165 +1,89 @@
 type Query {
   user(id: String): User
-  demoUser(id: String): DemoUser
+  # demoUser(id: String): DemoUser
 
-  """
-  Fetches an object given its ID
-  """
+  """Fetches an object given its ID"""
   node(
-    """
-    The ID of an object
-    """
+    """The ID of an object"""
     id: ID!
   ): Node
 }
 
 type User implements Node {
-  """
-  The ID of an object
-  """
+  """The ID of an object"""
   id: ID!
   userId: String!
-  todos(
-    status: String = "any"
-    after: String
-    first: Int
-    before: String
-    last: Int
-  ): TodoConnection
+  todos(status: String = "any", after: String, first: Int, before: String, last: Int): TodoConnection
   totalCount: Int!
   completedCount: Int!
 }
 
-type DemoUser implements Node {
-  id: ID!
-  userId: String!
-  username: String!
-  password: String!
-  email: String!
-  gender: Gender!
-  pizzaTopping: PizzaTopping!
-  age: Int!
-}
-
-enum Gender {
-  Non-binary
-  Female
-  Male
-}
-
-enum PizzaTopping {
-  Hawaiian
-  Hawaiian
-  Hawaiian
-  Hawaiian
-  Hawaiian
-  Hawaiian
-}
-
-"""
-An object with an ID
-"""
+"""An object with an ID"""
 interface Node {
-  """
-  The id of the object.
-  """
+  """The id of the object."""
   id: ID!
 }
 
-"""
-A connection to a list of items.
-"""
+"""A connection to a list of items."""
 type TodoConnection {
-  """
-  Information to aid in pagination.
-  """
+  """Information to aid in pagination."""
   pageInfo: PageInfo!
 
-  """
-  A list of edges.
-  """
+  """A list of edges."""
   edges: [TodoEdge]
 }
 
-"""
-Information about pagination in a connection.
-"""
+"""Information about pagination in a connection."""
 type PageInfo {
-  """
-  When paginating forwards, are there more items?
-  """
+  """When paginating forwards, are there more items?"""
   hasNextPage: Boolean!
 
-  """
-  When paginating backwards, are there more items?
-  """
+  """When paginating backwards, are there more items?"""
   hasPreviousPage: Boolean!
 
-  """
-  When paginating backwards, the cursor to continue.
-  """
+  """When paginating backwards, the cursor to continue."""
   startCursor: String
 
-  """
-  When paginating forwards, the cursor to continue.
-  """
+  """When paginating forwards, the cursor to continue."""
   endCursor: String
 }
 
-"""
-An edge in a connection.
-"""
+"""An edge in a connection."""
 type TodoEdge {
-  """
-  The item at the end of the edge
-  """
+  """The item at the end of the edge"""
   node: Todo
 
-  """
-  A cursor for use in pagination
-  """
+  """A cursor for use in pagination"""
   cursor: String!
 }
 
 type Todo implements Node {
-  """
-  The ID of an object
-  """
+  """The ID of an object"""
   id: ID!
   text: String!
   complete: Boolean!
 }
 
+# type DemoUser implements Node {
+#   """The ID of an object"""
+#   id: ID!
+#   userId: String!
+#   username: String!
+#   password: String!
+#   email: String!
+#   gender: String!
+#   pizzaTopping: String!
+#   age: String!
+# }
+
 type Mutation {
   addTodo(input: AddTodoInput!): AddTodoPayload
   changeTodoStatus(input: ChangeTodoStatusInput!): ChangeTodoStatusPayload
   markAllTodos(input: MarkAllTodosInput!): MarkAllTodosPayload
-  removeCompletedTodos(
-    input: RemoveCompletedTodosInput!
-  ): RemoveCompletedTodosPayload
+  removeCompletedTodos(input: RemoveCompletedTodosInput!): RemoveCompletedTodosPayload
   removeTodo(input: RemoveTodoInput!): RemoveTodoPayload
   renameTodo(input: RenameTodoInput!): RenameTodoPayload
-  addUser(input: AddUserInput!): AddUserPayload
-}
-
-input addUser {
-  username: String!
-  password: String!
-  email: String!
-  gender: Gender!
-  pizzaTopping: PizzaTopping!
-  age: Int!
-}
-
-type AddUserPayload {
-  id: ID!
-  userId: String!
-  username: String!
-  password: String!
-  email: String!
-  gender: Gender!
-  pizzaTopping: PizzaTopping!
-  age: Int!
+  # addUser(input: AddUserInput!): AddUserPayload
 }
 
 type AddTodoPayload {
@@ -232,3 +156,24 @@ input RenameTodoInput {
   text: String!
   clientMutationId: String
 }
+
+# type AddUserPayload {
+#   userId: String!
+#   username: String!
+#   password: String!
+#   email: String!
+#   gender: String!
+#   pizzaTopping: String!
+#   age: Int!
+#   clientMutationId: String
+# }
+
+# input AddUserInput {
+#   username: String!
+#   password: String!
+#   email: String!
+#   gender: String!
+#   pizzaTopping: String!
+#   age: Int!
+#   clientMutationId: String
+# }

--- a/todo/data/schema/index.js
+++ b/todo/data/schema/index.js
@@ -15,20 +15,20 @@ import {GraphQLObjectType, GraphQLSchema} from 'graphql';
 
 import {nodeField} from './nodes.js';
 import {UserQuery} from './queries/UserQuery';
-import {demoUserQuery} from './queries/demoUserQuery';
+// import {demoUserQuery} from './queries/demoUserQuery';
 import {AddTodoMutation} from './mutations/AddTodoMutation';
 import {ChangeTodoStatusMutation} from './mutations/ChangeTodoStatusMutation';
 import {MarkAllTodosMutation} from './mutations/MarkAllTodosMutation';
 import {RemoveCompletedTodosMutation} from './mutations/RemoveCompletedTodosMutation';
 import {RemoveTodoMutation} from './mutations/RemoveTodoMutation';
 import {RenameTodoMutation} from './mutations/RenameTodoMutation';
-import {AddUserMutation} from './mutations/AddUserMutation';
+// import {AddUserMutation} from './mutations/AddUserMutation';
 
 const Query = new GraphQLObjectType({
   name: 'Query',
   fields: {
     user: UserQuery,
-    demoUser: demoUserQuery,
+    // demoUser: demoUserQuery,
     node: nodeField,
   },
 });
@@ -42,7 +42,7 @@ const Mutation = new GraphQLObjectType({
     removeCompletedTodos: RemoveCompletedTodosMutation,
     removeTodo: RemoveTodoMutation,
     renameTodo: RenameTodoMutation,
-    addUser: AddUserMutation,
+    // addUser: AddUserMutation,
   },
 });
 

--- a/todo/data/schema/mutations/AddUserMutation.js
+++ b/todo/data/schema/mutations/AddUserMutation.js
@@ -1,52 +1,52 @@
-import {
-  cursorForObjectInConnection,
-  mutationWithClientMutationId,
-} from 'graphql-relay';
+// import {
+//   cursorForObjectInConnection,
+//   mutationWithClientMutationId,
+// } from 'graphql-relay';
 
-import {GraphQLID, GraphQLNonNull, GraphQLString, GraphQLInt} from 'graphql';
-import {GraphQLUser} from '../nodes';   // TODO: should I be using this some way?
+// import {GraphQLID, GraphQLNonNull, GraphQLString, GraphQLInt} from 'graphql';
+// import {GraphQLUser} from '../nodes';   // TODO: should I be using this some way?
 
-import {
-  addUser,
-  getDemoUserOrThrow
-} from '../../database';
+// import {
+//   addUser,
+//   getDemoUserOrThrow
+// } from '../../database';
 
-// TODO: replace with Typescript
-/*
-type Input = {|
-  +text: string,
-  +userId: string,
-|};
+// // TODO: replace with Typescript
+// /*
+// type Input = {|
+//   +text: string,
+//   +userId: string,
+// |};
 
-type Payload = {|
-  +todoId: string,
-  +userId: string,
-|};
-*/
+// type Payload = {|
+//   +todoId: string,
+//   +userId: string,
+// |};
+// */
 
-const AddUserMutation = mutationWithClientMutationId({
-  name: 'AddUser',
-  inputFields: {   // TODO
-    username: {type: new GraphQLNonNull(GraphQLString)},
-    password: {type: new GraphQLNonNull(GraphQLString)},
-    email: {type: new GraphQLNonNull(GraphQLString)},
-    gender: {type: new GraphQLNonNull(GraphQLString)},    // TODO: enum
-    pizzaTopping: {type: new GraphQLNonNull(GraphQLString)},    // TODO: enum
-    age: {type: new GraphQLNonNull(GraphQLInt)},
-  },
-  outputFields: {
-    userId: {type: new GraphQLNonNull(GraphQLString)},
-    username: {type: new GraphQLNonNull(GraphQLString)},
-    password: {type: new GraphQLNonNull(GraphQLString)},
-    email: {type: new GraphQLNonNull(GraphQLString)},
-    gender: {type: new GraphQLNonNull(GraphQLString)},    // TODO: enum
-    pizzaTopping: {type: new GraphQLNonNull(GraphQLString)},    // TODO: enum
-    age: {type: new GraphQLNonNull(GraphQLInt)},
-  },
-  mutateAndGetPayload: (input) => {
-    const userId = addUser(input);
-    return getDemoUserOrThrow(userId);
-  },
-});
+// const AddUserMutation = mutationWithClientMutationId({
+//   name: 'AddUser',
+//   inputFields: {   // TODO
+//     username: {type: new GraphQLNonNull(GraphQLString)},
+//     password: {type: new GraphQLNonNull(GraphQLString)},
+//     email: {type: new GraphQLNonNull(GraphQLString)},
+//     gender: {type: new GraphQLNonNull(GraphQLString)},    // TODO: enum
+//     pizzaTopping: {type: new GraphQLNonNull(GraphQLString)},    // TODO: enum
+//     age: {type: new GraphQLNonNull(GraphQLInt)},
+//   },
+//   outputFields: {
+//     userId: {type: new GraphQLNonNull(GraphQLString)},
+//     username: {type: new GraphQLNonNull(GraphQLString)},
+//     password: {type: new GraphQLNonNull(GraphQLString)},
+//     email: {type: new GraphQLNonNull(GraphQLString)},
+//     gender: {type: new GraphQLNonNull(GraphQLString)},    // TODO: enum
+//     pizzaTopping: {type: new GraphQLNonNull(GraphQLString)},    // TODO: enum
+//     age: {type: new GraphQLNonNull(GraphQLInt)},
+//   },
+//   mutateAndGetPayload: (input) => {
+//     const userId = addUser(input);
+//     return getDemoUserOrThrow(userId);
+//   },
+// });
 
-export {AddUserMutation};
+// export {AddUserMutation};

--- a/todo/data/schema/nodes.js
+++ b/todo/data/schema/nodes.js
@@ -32,12 +32,12 @@ import {
 import {
   Todo,
   User,
-  DemoUser,
+  // DemoUser,
   USER_ID,
   getTodoOrThrow,
   getTodos,
   getUserOrThrow,
-  getDemoUserOrThrow,
+  // getDemoUserOrThrow,
 } from '../database';
 
 // $FlowFixMe graphql-relay types not available in flow-typed, strengthen this typing
@@ -48,9 +48,10 @@ const {nodeInterface, nodeField} = nodeDefinitions(
       return getTodoOrThrow(id);
     } else if (type === 'User') {
       return getUserOrThrow(id);
-    } else if (type === 'DemoUser') {
-      return getDemoUserOrThrow(id);
-    }
+    } 
+    // else if (type === 'DemoUser') {
+    //   return getDemoUserOrThrow(id);
+    // }
     return null;
   },
   (obj: {}): ?GraphQLObjectType => {
@@ -126,40 +127,42 @@ const GraphQLUser = new GraphQLObjectType({
   interfaces: [nodeInterface],
 });
 
-const demoGraphQLUser = new GraphQLObjectType({
-  name: 'DemoUser',
-  fields: {
-    id: globalIdField('DemoUser'),
-    userId: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: (demoUser): string => demoUser.userId, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
-    },
-    username: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: (demoUser): string => demoUser.username, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
-    },
-    password: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: (demoUser): string => demoUser.password, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
-    },
-    email: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: (demoUser): string => demoUser.email, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
-    },
-    gender: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: (demoUser): string => demoUser.gender, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
-    },
-    pizzaTopping: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: (demoUser): string => demoUser.pizzaTopping, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
-    },
-    age: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: (demoUser): number => demoUser.age, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
-    },
-  },
-  interfaces: [nodeInterface],
-});
+// const demoGraphQLUser = new GraphQLObjectType({
+//   name: 'DemoUser',
+//   fields: {
+//     id: globalIdField('DemoUser'),
+//     userId: {
+//       type: new GraphQLNonNull(GraphQLString),
+//       resolve: (demoUser): string => demoUser.userId, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
+//     },
+//     username: {
+//       type: new GraphQLNonNull(GraphQLString),
+//       resolve: (demoUser): string => demoUser.username, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
+//     },
+//     password: {
+//       type: new GraphQLNonNull(GraphQLString),
+//       resolve: (demoUser): string => demoUser.password, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
+//     },
+//     email: {
+//       type: new GraphQLNonNull(GraphQLString),
+//       resolve: (demoUser): string => demoUser.email, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
+//     },
+//     gender: {
+//       type: new GraphQLNonNull(GraphQLString),
+//       resolve: (demoUser): string => demoUser.gender, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
+//     },
+//     pizzaTopping: {
+//       type: new GraphQLNonNull(GraphQLString),
+//       resolve: (demoUser): string => demoUser.pizzaTopping, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
+//     },
+//     age: {
+//       type: new GraphQLNonNull(GraphQLString),
+//       resolve: (demoUser): number => demoUser.age, // where does this value come from? mutation? methods come from database so maybe adding Demo methods there,
+//     },
+//   },
+//   interfaces: [nodeInterface],
+// });
 
-export {nodeField, GraphQLTodo, GraphQLTodoEdge, GraphQLUser, demoGraphQLUser};
+export {nodeField, GraphQLTodo, GraphQLTodoEdge, GraphQLUser, 
+  // DemoGraphQLUser
+};

--- a/todo/js/app.js
+++ b/todo/js/app.js
@@ -87,19 +87,20 @@ if (rootElement) {
       environment={modernEnvironment}
       // add demoUser to query and share with AddUser_demoUser?
       query={graphql`
-        query appQuery($userId: String, $demoUserId: String) {
+        # query appQuery($userId: String, $demoUserId: String) {
+        query appQuery($userId: String) {
           user(id: $userId) {
             ...TodoApp_user
           }
-          demoUser(id: $demoUserId) {
-            ...AddUser_demoUser
-          }
+          # demoUser(id: $demoUserId) {
+          #   ...AddUser_demoUser
+          # }
         }
       `}
       variables={{
         // Mock authenticated ID that matches database
         userId: 'me',
-        demoUserId: pieceofstate,
+        // demoUserId: pieceofstate,
       }}
       render={({error, props}: {error: ?Error, props: ?appQueryResponse}) => {
         if (props && props.user) {

--- a/todo/js/components/AddUser.js
+++ b/todo/js/components/AddUser.js
@@ -1,4 +1,5 @@
 
+// 
 // import React from 'react';
 // import {createFragmentContainer, graphql} from 'react-relay';
 // // import {PeriqlesForm} from '../../../index.js';

--- a/todo/js/components/AddUser.js
+++ b/todo/js/components/AddUser.js
@@ -1,61 +1,51 @@
-// @flow
-/**
- * This file provided by Facebook is for non-commercial testing and evaluation
- * purposes only.  Facebook reserves all rights not expressly granted.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
 
-import React from 'react';
-import {createFragmentContainer, graphql} from 'react-relay';
-// import {PeriqlesForm} from '../../../index.js';
-// import PeriqlesForm from './PeriqlesForm.js';
-import periqlesFormWrapper from './PeriqlesForm.js';
-import type {RelayProp} from 'react-relay';
-import type {TodoApp_user} from 'relay/TodoApp_user.graphql';
+// import React from 'react';
+// import {createFragmentContainer, graphql} from 'react-relay';
+// // import {PeriqlesForm} from '../../../index.js';
+// // import PeriqlesForm from './PeriqlesForm.js';
+// import periqlesFormWrapper from './PeriqlesForm.js';
+// /*
+// import type {RelayProp} from 'react-relay';
+// import type {TodoApp_user} from 'relay/TodoApp_user.graphql';
 
-type Props = {|
-  +relay: RelayProp,
-  +user: TodoApp_user,
-|};
+// type Props = {|
+//   +relay: RelayProp,
+//   +user: TodoApp_user,
+// |};
+// */
 
-const AddUser = ({relay, user}: Props) => {
-  // const handleTextInputSave = (text: string) => {
-  //   AddTodoMutation.commit(relay.environment, text, user);
-  //   return;
-  // };
+// const AddUser = ({relay, user}: Props) => {
+//   // const handleTextInputSave = (text: string) => {
+//   //   AddTodoMutation.commit(relay.environment, text, user);
+//   //   return;
+//   // };
 
 
-  // mock props for PeriqlesForm
+//   // mock props for PeriqlesForm
  
 
-  // // mock making closure
-  // const schema = [{name: 'name', type: 'String'}];
-  // const environment = {networkLayer: 'fake network layer', store: 'fake Relay store'};
-  // const PeriqlesForm = periqlesFormWrapper(schema, environment);
+//   // // mock making closure
+//   // const schema = [{name: 'name', type: 'String'}];
+//   // const environment = {networkLayer: 'fake network layer', store: 'fake Relay store'};
+//   // const PeriqlesForm = periqlesFormWrapper(schema, environment);
 
 
-  //Need to know:
-    //1: Prop name
-}
-export default AddUser;
+//   //Need to know:
+//     //1: Prop name
+// }
+// // export AddUser;
 
-export default createFragmentContainer(AddUser, {
-  user: graphql`
+// export default createFragmentContainer(AddUser, {
+//   user: graphql`
 
-    fragment AddUser_userInfo on DemoUser {
-      userId 
-      username 
-      password
-      email
-      gender
-      pizzaTopping
-      age
-    }
-`};
+//     fragment AddUser_userInfo on DemoUser {
+//       userId 
+//       username 
+//       password
+//       email
+//       gender
+//       pizzaTopping
+//       age
+//     }
+// `});
 

--- a/todo/js/components/PeriqlesForm.js
+++ b/todo/js/components/PeriqlesForm.js
@@ -1,49 +1,346 @@
 import React, {useState} from 'react';
-import commitMutation from 'react-relay'; // importing the mutation commit fn provided by Relay instead of expecting mutation prop to have a commit() method with params of a certain shape
+import commitMutation from 'react-relay';
+// importing the mutation commit fn provided by Relay instead of expecting mutation prop to have a commit() method with params of a certain shape
 
 /**
  * Wraps the PeriqlesForm component in a closure containing the Relay project's schema and RelayEnvironment.
- * @param {Object} Schema (REQUIRED) The graphQL schema used in this application  
- * @param {Object} Environment (REQUIRED) - The environment variable for this application containing the network layer and store
- * @return {Function} Returns an inner function PeriqlesForm? that generates a Periqles React form component 
+ * @param {Object} schema (REQUIRED) The GraphQL schema used in this application, provided implicitly by periqles.introspect().  
+ * @param {Object} environment (REQUIRED) The environment variable for this application, containing the network layer and store. Provided implicitly by periqles.introspect(). 
+ * @return {Function} PeriqlesForm, a React functional component
  * 
  */
  export default function periqlesFormWrapper (schema, environment){
 
+    // HELPER FUNCTIONS
+    /**
+     * Builds an HTML element to collect user input for a GraphQL mutation based on user-provided instructions.
+     * @param {Object} input An object representing an input field for a GraphQL mutation. Example: {name: "name", element: "text"}
+     * @param {Object} specs An object representing developer-specified information to use for an HTML element representing this field. Example: {label: "Name", element: "textarea", options: []}
+     * @return  Returns the specified HTML input element with the specified label and specified sub-options, if any.
+     * 
+     */
+    const generateSpecifiedElement = (input, specs) => {     
+        let element;
+        switch (specs.element) {
+            case 'range':
+                element = 
+                    <label>
+                    {specs.label}
+                    <input type="range"
+                        className={input.name + '-range periqles-range'} 
+                        name={input.name} 
+                        min={specs.min || 0} max={specs.max || Infinity}   
+                        value={formState[input.name].value} 
+                        onChange={handleChange}
+                    />
+                    </label>
+                    // note: dev may or may not include min and max values in specs; need fallback values to prevent throwing an error
+                break;
+            case 'image':
+                element = 
+                    <label>
+                    {specs.label}
+                        <input type="image"
+                            className ={input.name + '-image periqles-image'}
+                            name={input.name} 
+                            src={specs.src} alt={specs.label} 
+                            value={formState[input.name].value} 
+                            onChange={handleChange}
+                        />
+                    </label>
+                break;
+            // TODO: how to handle state and value of radio buttons?
+            case 'radio':
+                const radioOptions = [];
+                specs.options.forEach((radio) => {
+                    const radioInput = 
+                        <label>
+                            <input 
+                                type="radio" 
+                                className={input.name + '-radio-option periqles-radio-option'} 
+                                name={input.name} 
+                                />
+                            {specs.label}   
+                        </label>;
+                    radioOptions.push(radioInput);
+                })
+                element = 
+                    <div className={input.name + '-radio periqles-radio'}
+                        value={formState[input.name].value}
+                        onChange={handleChange}>
+                    {radioOptions}
+                    </div>
+                break;
+            // TODO: handle non-null/non-null-default dropdowns
+            case 'dropdown':
+                const selectOptions = [];
+                selectOptions.push(
+                    <option 
+                        value={null} 
+                        className={input.name + '-select-option periqles-select-option'} 
+                        selected
+                    >
+                    {specs.label}
+                    </option>);
+                specs.options.forEach((option) => {
+                    selectOptions.push(
+                    <option 
+                        value={option.value} 
+                        className={input.name + '-select-option periqles-select-option'}
+                        >
+                        {option.label}
+                    </option>)
+                })
+                element = 
+                    <select 
+                        className={input.name + '-select periqles-select'} 
+                        name={input.name}
+                        defaultValue={null} 
+                        onChange={handleChange}
+                    >
+                    {selectOptions}
+                    </select>;
+                break;
+            case 'textarea':
+                element = 
+                    <label>{specs.label}
+                        <textarea 
+                            className={input.name + '-textarea periqles-textarea'} 
+                            name={input.name}
+                            value={formState[input.name].value} 
+                            onChange={handleChange}
+                        />
+                    </label>; 
+                break;
+            default:
+                element = 
+                    <label>{specs.label}
+                        <input 
+                            type="text"
+                            className={input.name + '-input periqles-text'} 
+                            name={input.name} 
+                            value={formState[input.name].value} 
+                            onChange={handleChange}>
+                        </input>
+                    </label>
+        }
+    
+        return element;
+    }
+
+// TODO: use the options property added to enumerated fields
+const fieldsArrayGenerator = (mutationName, schema) => {
+  const fieldsArray = [];
+  const inputName = mutationName + 'Input';
+  console.log('Generating field object for this input field:', inputName);
+  let inputObj = schema[inputName];
+
+  inputObj.inputFields.forEach((inputField) => {
+    if(inputField.type.name === null) {
+        // if field type name is null, this field may be a sub-field of another type. Iterate over the types in the schema to find it.
+        for (const key in schema) {
+            // At each type, check if its fields array includes this field's name.
+            if (!schema[key].fields) return; 
+            if (!schema[key].fields.includes(inputField.name)) return;
+
+            schema[key].fields.forEach((field) => { 
+                if (field.name !== inputField.name) return;
+   
+                if (field.type.ofType.kind === 'SCALAR'){
+                    console.log('This field is a scalar field:', field.name);
+
+                    let fieldObj = {};
+                    fieldObj.name = field.name;
+                    fieldObj.element = field.type.ofType.name;
+                    fieldsArray.push(fieldObj);
+                    
+                    // inputField.type.name = field.type.ofType.name
+
+                } else if(field.type.kind === 'ENUM') {
+                    console.log('This field is an enumerated field:', field.name);
+                    let fieldObj = {
+                        name: field.name,
+                        element: 'Enum',
+                        options: {}
+                    };
+
+                    // TODO: Populate fieldObj.options. Check out inputFields and other properties of __EnumValue type on schema.
+                    /*
+                    allTypes.forEach((type)=>{
+                        if (field.type.name === type.name) {
+                            fieldObj.options = type.enumValues.name; //expecting this to be an object
+                        }
+                    });
+                    */
+
+                    fieldsArray.push(fieldObj);
+                } else {
+                    console.warn('inputField', inputField.name, 'matches a subfield of the', key, 'schema type, but it is not a scalar or enum type. This field\'s type is:', field.type);  
+                }
+            });
+        } 
+    }      
+    /*
+    } else if (inputField.type.kind == 'OBJECT' || inputField.type.name.type !== null) {
+        // TODO: What if input field is not scalar or enum but an object type? E.g., the "todos" field on User is of type TodoConnection. May require a recursive solution because types could be composed of arbitrarily nested objects.
+        console.warn('inputField', inputField.name, 'is an object type:', field.type.name, '. Assigning it a placeholder type for now.');     
+    } 
+    */
+    // input field type is not null, ie, scalar
+    else {
+        console.log('This field\'s type is not null:', inputField.type)
+        let fieldObj = {};
+        fieldObj.name = inputField.name;
+        fieldObj.element = inputField.type.name; 
+        fieldsArray.push(fieldObj); 
+    }
+  });
+  
+  return fieldsArray;
+}
+
+
+const generateDefaultElement = (fieldObj) => {
+    // assign a label that matches name but w/ spaces between words and first char uppercased
+    fieldObj.label = fieldObj.name.replace(/([a-z])([A-Z])/g, '$1 $2') 
+    fieldObj.label = fieldObj.label[0].toUpperCase() + fieldObj.label.slice(1);
+    
+    let element;
+
+    switch (fieldObj.element){
+      case 'Int':
+        element =
+          <label>{fieldObj.label}
+            <input 
+              type='number'
+              className={fieldObj.name + '-number periqles-number'} 
+              name={fieldObj.name} 
+              value={formState[fieldObj.name].value}
+              onChange={handleChange}>
+            </input>
+          </label>;
+          break;
+        
+      case 'Boolean':
+        element =
+          <label>{fieldObj.label}
+            <input 
+              type="checkbox"
+              className={fieldObj.name + '-checkbox periqles-checkbox'}
+              name={fieldObj.name}
+              value={formState[fieldObj.name].value}
+              onChange={handleChange}>
+            </input>
+          </label>;
+          break;
+
+      case 'Enum':
+        const optionsObj = fieldObj.options;
+        const selectOptions = [];
+
+        //iterate through the options for the field & make a tag for each option
+        for (const option in optionsObj){
+          selectOptions.push(
+            <option 
+              value={option} 
+              className={option + '-select-option'} 
+            >
+              {option}
+            </option>
+          );
+        }
+        
+        element = 
+          <label>{fieldObj.label}
+            <select 
+              className={fieldObj.name+ '-select'} 
+              name={fieldObj.name}
+              defaultValue={null} 
+              onChange={handleChange}
+              >
+                {selectOptions}
+            </select>
+          </label>;
+        break;
+       default:
+          element = 
+            <label>{fieldObj.label}
+              <input 
+                type='text'
+                className={fieldObj.name + '-input periqles-text'}
+                name={fieldObj.name} 
+                value={formState[fieldObj.name].value}
+                onChange={handleChange}>
+              </input>
+            </label>;
+            break; 
+
+    } 
+  return(element);
+}
+
+
+    /**
+     * By referencing the name of a mutation on a GraphQL schema, generates an HTML element for each field where user input is required. Assumes that if the mutation name takes the form of "<description>Mutation", its corresponding input type will be named "<description>Input".
+     * @param {Array} fieldsArray An array of objects representing the names and data types of input fields, deduced from an input type on the GraphQL schema.
+     * @param {string} mutationName The name of a GraphQL mutation exactly as it appears on the schema.
+     * @param {object} specifications
+     * @param {object} args An object whose keys represent the names of mutation input fields to exclude from the form, and whose values provide the value to be used for each variable when the mutation is committed. 
+     */
+
+    const formBuilder = (fields, specifications, args) => {
+      const formElementsArray = [];
+      //const fieldsArray = fieldsArrayGenerator(mutationName, schema);
+      fields.forEach((fieldObj) => {
+        if(args[fieldObj.name]) return;     // early return 
+
+        let element;
+        if(specifications.fields[fieldObj.name]){
+            element = generateSpecifiedElement(fieldObj, specifications.fields[fieldObj.name]);
+        } else {
+            element = generateDefaultElement(fieldObj);
+        }
+        formElementsArray.push(element);           
+      });
+      return formElementsArray;
+    }
+
   /**
    * A React functional component with input fields corresponding to a Relay mutation.
-   * @param {String} mutationName (REQUIRED) The name of a mutation as written on the Relay schema.
+   * @param {String} mutationName (REQUIRED) The name of a mutation axactly s written on the Relay schema.
    * @param {String} mutationGQL (REQUIRED) The GraphQL query string representing the mutation.
    * @param {Object} specifications Optional parameters to specify the form's elements. 
    * @param {[Object]} args Optional input values for the mutation, represented as objects with the shape {[nameOfInputField]: value}. Input fields represented here will not be represented on the form.
    * @return HTML
    */
+
   const PeriqlesForm = ({mutationName, mutationGQL, specifications, args}) => {  
-    // console.log('PeriqlesForm component successfully imported');
-    // console.log('PeriqlesForm is using this schema: ', schema);
+    console.log('PeriqlesForm is using this schema: ', schema);
+
     // STATE  
     const formState = {};   //--> { fieldName: { value: valueOfState, set: fnToSetState }};
-
-    // mock fields array
-    const fields = [{name: 'name', type: 'string'}, {name:'age', type:'number'}, {name:'gender', type:'string'}, {name:'over18', type:'boolean'}];
-
+    
+    // distill input fields from mutation schema
+    const fields = fieldsArrayGenerator(mutationName, schema);
+    console.log('Generated input fields array:', fields);
+    // assign an initial state for each field that reflects its data type
     fields.forEach((field) => {
-      // console.log('field object', field);
+    //   console.log('field object', field);
       let initialValue;
       switch (field.type) {
-        case 'string': 
+        case 'String': 
           initialValue = '';
           break;
-        case 'number':
+        case 'Int':
           initialValue = 0;
           break;
-        case 'boolean':
+        case 'Boolean':
           initialValue = false;
           break;
         default:
           initialValue = null;
       }
-      // Assign a piece of state and a setter function for each field
+      // Declare a piece of state and a setter function for each field
       const [value, set] = useState(initialValue);   
       formState[field.name] = {              
         value,
@@ -96,134 +393,57 @@ import commitMutation from 'react-relay'; // importing the mutation commit fn pr
       formState[name].set(value);
       // console.log('new state:', formState);
     }
-  
-    /**
-     * Builds a HTML form based on user provided parameters
-     * @param {String} mutation (REQUIRED) The name of the graphQL mutation used for the form. Example: 'addTodo'
-     * @param {Object} specifications (OPTIONAL) - an object containing fields to use with the form. Example: {fields: [{name: "name", element: "text", id: "textID"}]}
-     * @return  Returns a React Component with the generated form 
-     * 
-     */
-    const formBuilder = () => {
-      const formElements = [];
-      // iterate through specifications to get form fields order & mutation inputs
-      specifications.fields.forEach((input) => {
-        let element;
-        switch (input.element) {
-          case 'range':
-            element = 
-              <label>
-                {input.name}
-                  <input type = {input.element} 
-                    class = {input.name + '-range periqles-range'} 
-                    name = {input.name} 
-                    min = {input.min} max ={input.max}
-                    value={formState[input.name].value} 
-                    onChange={handleChange}
-                />
-              </label>
-            break;
-          case 'image':
-            element = 
-              <label>
-                {input.name}
-                  <input type = {input.element} 
-                      className = {input.name + '-image periqles-image'}
-                      name = {input.name} 
-                      src = {input.src} alt = {input.name} 
-                      value={formState[input.name].value} 
-                      onChange={handleChange}
-                  />
-              </label>
-            break;
-          // TODO: how to handle state of radio buttons?
-          case 'radio':
-            const radioOptions = [];
-            input.options.forEach((radio) => {
-              const radioInput = 
-                <label>
-                  <input 
-                    type="radio" 
-                    className={input.name + '-radio-option periqles-radio-option'} 
-                    name={input.name} 
-                    value={radio.value}/>   
-                </label>;
-              radioOptions.push(radioInput);
-            })
-            element = 
-              <div className={input.name + '-radio periqles-radio'}>
-                {radioOptions}
-              </div>
-            break;
-          // TODO: handle non-null/non-null-default dropdowns
-          case 'dropdown':
-            const selectOptions = [];
-            selectOptions.push(
-              <option 
-                value={null} 
-                className={input.name + '-select-option periqles-select-option'} 
-                selected>
-                  {input.name}
-              </option>);
-            input.options.forEach((option) => {
-              selectOptions.push(
-                <option 
-                  value={option.value} 
-                  className={input.name + '-select-option periqles-select-option'}
-                  >
-                    {option.name}
-                </option>)
-            })
-            element = 
-              <select 
-                className={input.name + '-select periqles-select'} 
-                name={input.name}
-                defaultValue={null} 
-                onChange={handleChange}
-                >
-                  {selectOptions}
-              </select>;
-            break;
-          case 'textarea':
-            element = 
-              <label>{input.name}
-                <textarea 
-                  className={input.name + '-textarea periqles-textarea'} 
-                  name={input.name}
-                  placeholder={input.name}
-                  value={formState[input.name].value} 
-                  onChange={handleChange}
-                  />
-              </label>; 
-            break;
-          default:
-            element = 
-              <label>{input.name}
-                <input 
-                  type={input.element || 'text'}
-                  className={input.name + '-input periqles-text'} 
-                  name={input.name} 
-                  value={formState[input.name].value} 
-                  placeholder={input.name}
-                  onChange={handleChange}>
-                </input>
-              </label>
-        }
-  
-        formElements.push(element);
-      });
-  
-      return formElements;
-    }
-  
+
+    // ADDITIONAL ELEMENTS AND STYLES
+    let headerText = mutationName.replace('Mutation', '')                  
+                                    .replace(/([a-z])([A-Z])/g, '$1 $2');  // add spaces before capital letters
+    headerText = headerText[0].toUpperCase() + headerText.slice(1);        // capitalize first letter                                
+    
     return (
-      <form className="PeriqlesForm"
-            onSubmit={handleSubmit}>
-        {formBuilder()}
-        <button onClick={handleSubmit}>Submit</button>
-      </form>
+        // TODO: Add a handler to div to permit submitting with an "enter" keydown event anywhere inside the div
+        <div className="PeriqlesForm"
+            aria-labelledby= "form">
+            <h2>{headerText}</h2>
+            {formBuilder(fields, specifications, args)}
+            <button onClick={handleSubmit}>Submit</button>
+        </div>
     )
-  }
-  
-  return PeriqlesForm;
+    }
+    
+    return PeriqlesForm;
 }
+
+
+/*
+// mock props
+  const schema = {name: {name: 'name', type: 'String'}};
+const environment = {'networkLayer': 'fake network layer', 'store': 'fake Relay store'};
+const mutation = 'AddTodoMutation';
+const mutationGQL = `mutation AddTodoMutation($input: AddTodoInput) { }`
+const specifications = {
+    fields: {
+        name: {
+            label: "Name",
+            element: "text",
+        },
+        gender: {
+            label: "Gender",
+            element: "radio",
+            options: [
+              {label: "male", value: "m"},
+              {label:"female", value: "f"},
+              {label: "non-binary", value: "x"},
+            ],
+        }
+    },
+};
+*/
+
+  
+
+  /*FORM VAILDATION NOTES:
+      https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation#what_is_form_validation
+      -input type tags generally have built-in validation
+      -required tag: eg. <input type="text" id="username" name="username" required></input>
+      -input type tell can specify a pattern: <input type="tel" id="phone" name="phone" placeholder="123-45-678" pattern="[0-9]{3}-[0-9]{2}-[0-9]{3}" required></input>
+        */

--- a/todo/js/components/PeriqlesForm.js
+++ b/todo/js/components/PeriqlesForm.js
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import commitMutation from 'react-relay';
+import {commitMutation, graphql} from 'react-relay';
 // importing the mutation commit fn provided by Relay instead of expecting mutation prop to have a commit() method with params of a certain shape
 
 /**
@@ -11,156 +11,50 @@ import commitMutation from 'react-relay';
  */
  export default function periqlesFormWrapper (schema, environment){
 
-    // HELPER FUNCTIONS
-    /**
-     * Builds an HTML element to collect user input for a GraphQL mutation based on user-provided instructions.
-     * @param {Object} input An object representing an input field for a GraphQL mutation. Example: {name: "name", element: "text"}
-     * @param {Object} specs An object representing developer-specified information to use for an HTML element representing this field. Example: {label: "Name", element: "textarea", options: []}
-     * @return  Returns the specified HTML input element with the specified label and specified sub-options, if any.
-     * 
-     */
-    const generateSpecifiedElement = (input, specs) => {     
-        let element;
-        switch (specs.element) {
-            case 'range':
-                element = 
-                    <label>
-                    {specs.label}
-                    <input type="range"
-                        className={input.name + '-range periqles-range'} 
-                        name={input.name} 
-                        min={specs.min || 0} max={specs.max || Infinity}   
-                        value={formState[input.name].value} 
-                        onChange={handleChange}
-                    />
-                    </label>
-                    // note: dev may or may not include min and max values in specs; need fallback values to prevent throwing an error
-                break;
-            case 'image':
-                element = 
-                    <label>
-                    {specs.label}
-                        <input type="image"
-                            className ={input.name + '-image periqles-image'}
-                            name={input.name} 
-                            src={specs.src} alt={specs.label} 
-                            value={formState[input.name].value} 
-                            onChange={handleChange}
-                        />
-                    </label>
-                break;
-            // TODO: how to handle state and value of radio buttons?
-            case 'radio':
-                const radioOptions = [];
-                specs.options.forEach((radio) => {
-                    const radioInput = 
-                        <label>
-                            <input 
-                                type="radio" 
-                                className={input.name + '-radio-option periqles-radio-option'} 
-                                name={input.name} 
-                                />
-                            {specs.label}   
-                        </label>;
-                    radioOptions.push(radioInput);
-                })
-                element = 
-                    <div className={input.name + '-radio periqles-radio'}
-                        value={formState[input.name].value}
-                        onChange={handleChange}>
-                    {radioOptions}
-                    </div>
-                break;
-            // TODO: handle non-null/non-null-default dropdowns
-            case 'dropdown':
-                const selectOptions = [];
-                selectOptions.push(
-                    <option 
-                        value={null} 
-                        className={input.name + '-select-option periqles-select-option'} 
-                        selected
-                    >
-                    {specs.label}
-                    </option>);
-                specs.options.forEach((option) => {
-                    selectOptions.push(
-                    <option 
-                        value={option.value} 
-                        className={input.name + '-select-option periqles-select-option'}
-                        >
-                        {option.label}
-                    </option>)
-                })
-                element = 
-                    <select 
-                        className={input.name + '-select periqles-select'} 
-                        name={input.name}
-                        defaultValue={null} 
-                        onChange={handleChange}
-                    >
-                    {selectOptions}
-                    </select>;
-                break;
-            case 'textarea':
-                element = 
-                    <label>{specs.label}
-                        <textarea 
-                            className={input.name + '-textarea periqles-textarea'} 
-                            name={input.name}
-                            value={formState[input.name].value} 
-                            onChange={handleChange}
-                        />
-                    </label>; 
-                break;
-            default:
-                element = 
-                    <label>{specs.label}
-                        <input 
-                            type="text"
-                            className={input.name + '-input periqles-text'} 
-                            name={input.name} 
-                            value={formState[input.name].value} 
-                            onChange={handleChange}>
-                        </input>
-                    </label>
-        }
-    
-        return element;
-    }
-
-// TODO: use the options property added to enumerated fields
-const fieldsArrayGenerator = (mutationName, schema) => {
+  // TODO: use the options property added to enumerated fields
+  const fieldsArrayGenerator = (mutationName, args) => {
   const fieldsArray = [];
+  // exclude from the form any inputs accounted for by args
+  const exclude = args.map((arg) => arg.name);
   const inputName = mutationName + 'Input';
-  console.log('Generating field object for this input field:', inputName);
+  // console.log('Generating field objects for this input type:', inputName);
   let inputObj = schema[inputName];
 
   inputObj.inputFields.forEach((inputField) => {
+    // console.log('Current input field:', inputField);
+    if (exclude.includes(inputField.name)) return;
+    
     if(inputField.type.name === null) {
         // if field type name is null, this field may be a sub-field of another type. Iterate over the types in the schema to find it.
-        for (const key in schema) {
-            // At each type, check if its fields array includes this field's name.
-            if (!schema[key].fields) return; 
-            if (!schema[key].fields.includes(inputField.name)) return;
+        Object.keys(schema).forEach(key => {
+          // console.log('Currently checking this type:', key, schema[key]);
+            // At each type, check if it has a fields array including this field's name.
+            if (!schema[key].fields) { 
+              // console.log(`Schema type ${key} has no fields -- returning.`);
+              return; 
+            }
+            // error: inputField.name is a string, but fields is an array of objects
+            // if (!schema[key].fields.includes(inputField.name)) {console.log(`Schema type ${key} has fields, but none matching '${inputField.name}'.`);return;}
 
             schema[key].fields.forEach((field) => { 
+                // console.log('current field name: ', field.name);
                 if (field.name !== inputField.name) return;
-   
+  
                 if (field.type.ofType.kind === 'SCALAR'){
-                    console.log('This field is a scalar field:', field.name);
+                    // console.log('This field is a scalar field:', field.name);
 
-                    let fieldObj = {};
+                    const fieldObj = {};
                     fieldObj.name = field.name;
-                    fieldObj.element = field.type.ofType.name;
+                    fieldObj.type = field.type.ofType.name;
                     fieldsArray.push(fieldObj);
-                    
+                    return;
                     // inputField.type.name = field.type.ofType.name
 
                 } else if(field.type.kind === 'ENUM') {
-                    console.log('This field is an enumerated field:', field.name);
-                    let fieldObj = {
+                    // console.log('This field is an enumerated field:', field.name);
+                    const fieldObj = {
                         name: field.name,
-                        element: 'Enum',
+                        type: 'Enum',
                         options: {}
                     };
 
@@ -174,11 +68,18 @@ const fieldsArrayGenerator = (mutationName, schema) => {
                     */
 
                     fieldsArray.push(fieldObj);
+                    return;
                 } else {
-                    console.warn('inputField', inputField.name, 'matches a subfield of the', key, 'schema type, but it is not a scalar or enum type. This field\'s type is:', field.type);  
+                    console.warn('inputField', inputField.name, 'matches a subfield of the', key, 'schema type, but it is not a scalar or enum type. This field\'s type is:', field.type, '. Defaulting to string.');  
+                    const fieldObj = {
+                      name: field.name,
+                      type: 'String',
+                    };
+                    fieldsArray.push(fieldObj);
+                    return;
                 }
             });
-        } 
+        }); 
     }      
     /*
     } else if (inputField.type.kind == 'OBJECT' || inputField.type.name.type !== null) {
@@ -188,122 +89,19 @@ const fieldsArrayGenerator = (mutationName, schema) => {
     */
     // input field type is not null, ie, scalar
     else {
-        console.log('This field\'s type is not null:', inputField.type)
-        let fieldObj = {};
-        fieldObj.name = inputField.name;
-        fieldObj.element = inputField.type.name; 
-        fieldsArray.push(fieldObj); 
+        // console.log('This field\'s type is not null:', inputField)
+        let fieldObj = {
+          name: inputField.name,
+          type: inputField.type.name,
+        };
+        fieldsArray.push(fieldObj);
+        return; 
     }
   });
-  
+
   return fieldsArray;
 }
 
-
-const generateDefaultElement = (fieldObj) => {
-    // assign a label that matches name but w/ spaces between words and first char uppercased
-    fieldObj.label = fieldObj.name.replace(/([a-z])([A-Z])/g, '$1 $2') 
-    fieldObj.label = fieldObj.label[0].toUpperCase() + fieldObj.label.slice(1);
-    
-    let element;
-
-    switch (fieldObj.element){
-      case 'Int':
-        element =
-          <label>{fieldObj.label}
-            <input 
-              type='number'
-              className={fieldObj.name + '-number periqles-number'} 
-              name={fieldObj.name} 
-              value={formState[fieldObj.name].value}
-              onChange={handleChange}>
-            </input>
-          </label>;
-          break;
-        
-      case 'Boolean':
-        element =
-          <label>{fieldObj.label}
-            <input 
-              type="checkbox"
-              className={fieldObj.name + '-checkbox periqles-checkbox'}
-              name={fieldObj.name}
-              value={formState[fieldObj.name].value}
-              onChange={handleChange}>
-            </input>
-          </label>;
-          break;
-
-      case 'Enum':
-        const optionsObj = fieldObj.options;
-        const selectOptions = [];
-
-        //iterate through the options for the field & make a tag for each option
-        for (const option in optionsObj){
-          selectOptions.push(
-            <option 
-              value={option} 
-              className={option + '-select-option'} 
-            >
-              {option}
-            </option>
-          );
-        }
-        
-        element = 
-          <label>{fieldObj.label}
-            <select 
-              className={fieldObj.name+ '-select'} 
-              name={fieldObj.name}
-              defaultValue={null} 
-              onChange={handleChange}
-              >
-                {selectOptions}
-            </select>
-          </label>;
-        break;
-       default:
-          element = 
-            <label>{fieldObj.label}
-              <input 
-                type='text'
-                className={fieldObj.name + '-input periqles-text'}
-                name={fieldObj.name} 
-                value={formState[fieldObj.name].value}
-                onChange={handleChange}>
-              </input>
-            </label>;
-            break; 
-
-    } 
-  return(element);
-}
-
-
-    /**
-     * By referencing the name of a mutation on a GraphQL schema, generates an HTML element for each field where user input is required. Assumes that if the mutation name takes the form of "<description>Mutation", its corresponding input type will be named "<description>Input".
-     * @param {Array} fieldsArray An array of objects representing the names and data types of input fields, deduced from an input type on the GraphQL schema.
-     * @param {string} mutationName The name of a GraphQL mutation exactly as it appears on the schema.
-     * @param {object} specifications
-     * @param {object} args An object whose keys represent the names of mutation input fields to exclude from the form, and whose values provide the value to be used for each variable when the mutation is committed. 
-     */
-
-    const formBuilder = (fields, specifications, args) => {
-      const formElementsArray = [];
-      //const fieldsArray = fieldsArrayGenerator(mutationName, schema);
-      fields.forEach((fieldObj) => {
-        if(args[fieldObj.name]) return;     // early return 
-
-        let element;
-        if(specifications.fields[fieldObj.name]){
-            element = generateSpecifiedElement(fieldObj, specifications.fields[fieldObj.name]);
-        } else {
-            element = generateDefaultElement(fieldObj);
-        }
-        formElementsArray.push(element);           
-      });
-      return formElementsArray;
-    }
 
   /**
    * A React functional component with input fields corresponding to a Relay mutation.
@@ -315,17 +113,18 @@ const generateDefaultElement = (fieldObj) => {
    */
 
   const PeriqlesForm = ({mutationName, mutationGQL, specifications, args}) => {  
-    console.log('PeriqlesForm is using this schema: ', schema);
+    // console.log('PeriqlesForm is using this schema: ', schema);
+    console.log('PeriqlesForm will exclude these args:', args);
 
     // STATE  
     const formState = {};   //--> { fieldName: { value: valueOfState, set: fnToSetState }};
     
     // distill input fields from mutation schema
-    const fields = fieldsArrayGenerator(mutationName, schema);
-    console.log('Generated input fields array:', fields);
-    // assign an initial state for each field that reflects its data type
+    const fields = fieldsArrayGenerator(mutationName, args);
+    console.log('Generated input fields array:', fields);   // TODO: why does AddTodoInput generate a field object for the 'text' field that has a label of 'Text'?
+    // assign an initial state for each field that reflects its data type (called 'element')
     fields.forEach((field) => {
-    //   console.log('field object', field);
+      // console.log('field object', field);
       let initialValue;
       switch (field.type) {
         case 'String': 
@@ -338,7 +137,7 @@ const generateDefaultElement = (fieldObj) => {
           initialValue = false;
           break;
         default:
-          initialValue = null;
+          initialValue = '';
       }
       // Declare a piece of state and a setter function for each field
       const [value, set] = useState(initialValue);   
@@ -348,6 +147,7 @@ const generateDefaultElement = (fieldObj) => {
       };
     });
     
+    // console.log('commitMutation:', commitMutation);
     
     // HANDLERS
     /**
@@ -358,29 +158,30 @@ const generateDefaultElement = (fieldObj) => {
         e.preventDefault();   // prevent page refesh 
       }
       
-      // populate $input for mutation
       const input = {
-        clientMutationId,      // TODO: How to get this in scope? Is this needed for every commit?
+        // clientMutationId,      // TODO: Can we arbitrarily assign this like they do in js/mutations/AddTodoMutation.js?
       };
       Object.keys(formState).forEach(key => {
         input[key] = formState[key].value;
       });
       if (args) {
-        args.forEach(([key, value]) => {
-          input[key] = value;
+        args.forEach(({name, value}) => {
+          input[name] = value;
         });
       }
-  
+
+      console.log(mutationGQL);
+
       // Documentation re: shape of commitMutation's second parameter: https://relay.dev/docs/en/mutations#arguments
       // Referencing use of commitMutation in js/mutations/AddTodoMutation
       const variables = {
         input,
       };
       commitMutation(environment, {
-        mutationString,       // --> MUST BE A QUERY STRING
+        mutation: mutationGQL,
         variables,
         onCompleted: (response, errors) => console.log('Server response to mutation:', response, errors),
-        onError: (err) => console.error(err)
+        onError: (err) => console.error('Problem committing mutation:', err),
       });   
     }
       
@@ -394,9 +195,242 @@ const generateDefaultElement = (fieldObj) => {
       // console.log('new state:', formState);
     }
 
+    // HELPER FUNCTIONS
+    /**
+     * Builds an HTML element to collect user input for a GraphQL mutation based on user-provided instructions.
+     * @param {Object} input An object representing an input field for a GraphQL mutation. Example: {name: "name", type: "String"}
+     * @param {Object} specs An object representing developer-specified information to use for an HTML element representing this field. Example: {label: "Name", element: "textarea", options: []}
+     * @return  Returns the specified HTML input element with the specified label and specified sub-options, if any.
+     * 
+     */
+    const generateSpecifiedElement = (input) => {     
+      let element;
+      switch (specs.element) {
+        case 'range':
+          element = 
+              <label>
+              {specs.label}
+              <input type="range"
+                  className={input.name + '-range periqles-range'} 
+                  name={input.name} 
+                  min={specs.min || 0} max={specs.max || Infinity}   
+                  value={formState[input.name].value} 
+                  onChange={handleChange}
+              />
+              </label>
+              // note: dev may or may not include min and max values in specs; need fallback values to prevent throwing an error
+          break;
+        case 'image':
+          element = 
+              <label>
+              {specs.label}
+                  <input type="image"
+                      className ={input.name + '-image periqles-image'}
+                      name={input.name} 
+                      src={specs.src} alt={specs.label} 
+                      value={formState[input.name].value} 
+                      onChange={handleChange}
+                  />
+              </label>
+          break;
+        // TODO: how to handle state and value of radio buttons?
+        case 'radio':
+          const radioOptions = [];
+          specs.options.forEach((radio) => {
+              const radioInput = 
+                  <label>
+                      <input 
+                          type="radio" 
+                          name={input.name} 
+                          className={input.name + '-radio-option periqles-radio-option'}
+                          value={radio.value} 
+                          />
+                      {specs.label}   
+                  </label>;
+              radioOptions.push(radioInput);
+          })
+          element = 
+              <div className={input.name + '-radio periqles-radio'}
+                  value={formState[input.name].value}
+                  onChange={handleChange}>
+              {radioOptions}
+              </div>
+          break;
+        // TODO: handle non-null/non-null-default dropdowns
+        case 'dropdown':
+            const selectOptions = [];
+            selectOptions.push(
+                <option 
+                    value={''} 
+                    className={input.name + '-select-option periqles-select-option'} 
+                    selected
+                >
+                {specs.label}
+                </option>);
+            specs.options.forEach((option) => {
+                selectOptions.push(
+                <option 
+                    value={option.value} 
+                    className={input.name + '-select-option periqles-select-option'}
+                    >
+                    {option.label}
+                </option>)
+            })
+            element = 
+                <select 
+                    className={input.name + '-select periqles-select'} 
+                    name={input.name}
+                    defaultValue={''} 
+                    onChange={handleChange}
+                >
+                {selectOptions}
+                </select>;
+            break;
+        case 'textarea':
+            element = 
+                <label>{specs.label}
+                    <textarea 
+                        className={input.name + '-textarea periqles-textarea'} 
+                        name={input.name}
+                        value={formState[input.name].value} 
+                        onChange={handleChange}
+                    />
+                </label>; 
+            break;
+        default:
+            element = 
+                <label>{specs.label}
+                    <input 
+                        type="text"
+                        className={input.name + '-input periqles-text'} 
+                        name={input.name} 
+                        value={formState[input.name].value} 
+                        onChange={handleChange}>
+                    </input>
+                </label>
+      }
+  
+      return element;
+    }
+
+    const generateDefaultElement = (fieldObj) => {
+      // assign a label that matches name but w/ spaces between words and first char uppercased
+      fieldObj.label = fieldObj.name.replace(/([a-z])([A-Z])/g, '$1 $2') 
+      fieldObj.label = fieldObj.label[0].toUpperCase() + fieldObj.label.slice(1);
+      
+      let element;
+
+      switch (fieldObj.type){
+        case 'Int':
+          element =
+            <label>{fieldObj.label}
+              <input 
+                type='number'
+                className={fieldObj.name + '-number periqles-number'} 
+                name={fieldObj.name} 
+                value={formState[fieldObj.name].value}
+                onChange={handleChange}>
+              </input>
+            </label>;
+            break;
+          
+        case 'Boolean':
+          element =
+            <label>{fieldObj.label}
+              <input 
+                type="checkbox"
+                className={fieldObj.name + '-checkbox periqles-checkbox'}
+                name={fieldObj.name}
+                value={formState[fieldObj.name].value}
+                onChange={handleChange}>
+              </input>
+            </label>;
+            break;
+
+        case 'Enum':
+          const optionsObj = fieldObj.options;
+          const selectOptions = [];
+          // default value displays label of field
+          selectOptions.push(
+            <option 
+                value={''} 
+                className={input.name + '-select-option periqles-select-option'} 
+                selected
+            >
+            {specs.label}
+            </option>);
+          //iterate through the options for the field & make a tag for each option
+          // TODO: check shape of options collection
+          for (const option in optionsObj){
+            selectOptions.push(
+              <option 
+                value={option.value} 
+                className={option + '-select-option'} 
+              >
+                {option}
+              </option>
+            );
+          }
+          
+          element = 
+            <label>{fieldObj.label}
+              <select 
+                className={fieldObj.name+ '-select'} 
+                name={fieldObj.name}
+                defaultValue={''} 
+                onChange={handleChange}
+                >
+                  {selectOptions}
+              </select>
+            </label>;
+          break;
+        default:
+            element = 
+              <label>{fieldObj.label}
+                <input 
+                  type='text'
+                  className={fieldObj.name + '-input periqles-text'}
+                  name={fieldObj.name} 
+                  value={formState[fieldObj.name].value}
+                  onChange={handleChange}>
+                </input>
+              </label>;
+              break; 
+
+      }
+
+      return(element);
+    }
+
+
+    /**
+     * By referencing the name of a mutation on a GraphQL schema, generates an HTML element for each field where user input is required. Assumes that if the mutation name takes the form of "<description>Mutation", its corresponding input type will be named "<description>Input".
+     * @param {Array} fieldsArray An array of objects representing the names and data types of input fields, deduced from an input type on the GraphQL schema.
+     * @param {string} mutationName The name of a GraphQL mutation exactly as it appears on the schema.
+     * @param {object} specifications
+     * @param {object} args An object whose keys represent the names of mutation input fields to exclude from the form, and whose values provide the value to be used for each variable when the mutation is committed. 
+     */
+
+    const formBuilder = (fields) => {
+      const formElementsArray = [];
+      //const fieldsArray = fieldsArrayGenerator(mutationName, schema);
+      fields.forEach((fieldObj) => {
+        if(args[fieldObj.name]) return;     // early return 
+
+        let element;
+        if(specifications.fields[fieldObj.name]){
+          element = generateSpecifiedElement(fieldObj, specifications.fields[fieldObj.name]);
+        } else {
+          element = generateDefaultElement(fieldObj);
+        }
+        formElementsArray.push(element);           
+      });
+      return formElementsArray;
+    }
+
     // ADDITIONAL ELEMENTS AND STYLES
     let headerText = mutationName.replace('Mutation', '')                  
-                                    .replace(/([a-z])([A-Z])/g, '$1 $2');  // add spaces before capital letters
+                                  .replace(/([a-z])([A-Z])/g, '$1 $2');  // add spaces before capital letters
     headerText = headerText[0].toUpperCase() + headerText.slice(1);        // capitalize first letter                                
     
     return (
@@ -404,13 +438,14 @@ const generateDefaultElement = (fieldObj) => {
         <div className="PeriqlesForm"
             aria-labelledby= "form">
             <h2>{headerText}</h2>
-            {formBuilder(fields, specifications, args)}
+            {formBuilder(fields)}
             <button onClick={handleSubmit}>Submit</button>
         </div>
     )
-    }
     
-    return PeriqlesForm;
+  }
+    
+  return PeriqlesForm;
 }
 
 

--- a/todo/js/components/PeriqlesForm.js
+++ b/todo/js/components/PeriqlesForm.js
@@ -113,14 +113,14 @@ import {commitMutation, graphql} from 'react-relay';
 
   const PeriqlesForm = ({mutationName, mutationGQL, specifications, args}) => {  
     // console.log('PeriqlesForm is using this schema: ', schema);
-    console.log('PeriqlesForm will exclude these args:', args);
+    // console.log('PeriqlesForm will exclude these args:', args);
 
     // STATE  
     const formState = {};   //--> { fieldName: { value: valueOfState, set: fnToSetState }};
     
     // distill input fields from mutation schema
     const fields = fieldsArrayGenerator(mutationName, args);
-    console.log('Generated input fields array:', fields);   // TODO: why does AddTodoInput generate a field object for the 'text' field that has a label of 'Text'?
+    // console.log('Generated input fields array:', fields);   // TODO: why does AddTodoInput generate a field object for the 'text' field that has a label of 'Text'?
     // assign an initial state for each field that reflects its data type (called 'element')
     fields.forEach((field) => {
       // console.log('field object', field);

--- a/todo/js/components/PeriqlesForm.js
+++ b/todo/js/components/PeriqlesForm.js
@@ -43,13 +43,12 @@ import {commitMutation, graphql} from 'react-relay';
                 if (field.type.ofType.kind === 'SCALAR'){
                     // console.log('This field is a scalar field:', field.name);
 
-                    const fieldObj = {};
-                    fieldObj.name = field.name;
-                    fieldObj.type = field.type.ofType.name;
+                    const fieldObj = {
+                      name: field.name,
+                      type: field.type.ofType.name,
+                    };
                     fieldsArray.push(fieldObj);
                     return;
-                    // inputField.type.name = field.type.ofType.name
-
                 } else if(field.type.kind === 'ENUM') {
                     // console.log('This field is an enumerated field:', field.name);
                     const fieldObj = {

--- a/todo/js/components/TodoApp.js
+++ b/todo/js/components/TodoApp.js
@@ -10,7 +10,6 @@
  * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 import AddTodoMutation from '../mutations/AddTodoMutation';
 import TodoList from './TodoList';
 import TodoListFooter from './TodoListFooter';
@@ -21,6 +20,7 @@ import {createFragmentContainer, graphql} from 'react-relay';
 // import {PeriqlesForm} from '../../../index.js';
 // import PeriqlesForm from './PeriqlesForm.js';
 import periqlesFormWrapper from './PeriqlesForm.js';
+import {schema} from './schema.js';
 import type {RelayProp} from 'react-relay';
 import type {TodoApp_user} from 'relay/TodoApp_user.graphql';
 
@@ -38,32 +38,29 @@ const TodoApp = ({relay, user}: Props) => {
   const hasTodos = user.totalCount > 0;
 
   // mock props for PeriqlesForm
-  const mutation = '';
+  const mutation = 'AddTodo';
   const specifications = {
-    fields: [
-      {
-        name: 'name',
-        element: 'text',
-        id: 'textId',
-      },
-      {
-        name: 'gender',
-        element: 'radio',
-        options: [
-          {name: 'male', value: 'm'},
-          {name: 'female', value: 'f'},
-          {name: 'prefer not to say', value: 'x'},
-        ],
-        id: 'radioId',
-      },
-    ],
-    args: [{name: 'userID', value: 'me'}],
-  };
+    fields: {
+        name: {
+            label: "Name",
+            element: "text",
+        },
+        gender: {
+            label: "Gender",
+            element: "radio",
+            options: [
+              {label: "male", value: "m"},
+              {label:"female", value: "f"},
+              {label: "non-binary", value: "x"},
+            ],
+        }
+    },
+};
 
   // mock making closure
-  const schema = [{name: 'name', type: 'String'}];
+  console.log('Relay environment:', relay.environment);
   const environment = {networkLayer: 'fake network layer', store: 'fake Relay store'};
-  const PeriqlesForm = periqlesFormWrapper(schema, environment);
+  const PeriqlesForm = periqlesFormWrapper(schema, relay.environment);
 
   return (
     <div>

--- a/todo/js/components/TodoApp.js
+++ b/todo/js/components/TodoApp.js
@@ -16,11 +16,11 @@ import TodoListFooter from './TodoListFooter';
 import TodoTextInput from './TodoTextInput';
 
 import React from 'react';
-import {createFragmentContainer, graphql} from 'react-relay';
+import {createFragmentContainer, commitMutation, graphql} from 'react-relay';
 // import {PeriqlesForm} from '../../../index.js';
 // import PeriqlesForm from './PeriqlesForm.js';
 import periqlesFormWrapper from './PeriqlesForm.js';
-import {schema} from './schema.js';
+import schema from './schema.js';
 import type {RelayProp} from 'react-relay';
 import type {TodoApp_user} from 'relay/TodoApp_user.graphql';
 
@@ -55,11 +55,47 @@ const TodoApp = ({relay, user}: Props) => {
             ],
         }
     },
-};
+  };
+
+  const mutationGQL = graphql`
+  mutation AddTodoMutation($input: AddTodoInput!) {
+    addTodo(input: $input) {
+      todoEdge {
+        __typename
+        cursor
+        node {
+          complete
+          id
+          text
+        }
+      }
+      user {
+        id
+        totalCount
+      }
+    }
+  }`;
+
+  const input = {
+    text: 'Race Usain Bolt',
+    clientMutationId:'0000',
+    userId: 'me',
+  };
+  const variables = {
+    input,
+  };
+
+  // commitMutation(relay.environment, {
+  //   mutationGQL,
+  //   variables,
+  //   onCompleted: (response, errors) => console.log('Server response to mutation:', response, errors),
+  //   onError: (err) => console.error('Problem committing mutation:', err),
+  // });   
 
   // mock making closure
-  console.log('Relay environment:', relay.environment);
-  const environment = {networkLayer: 'fake network layer', store: 'fake Relay store'};
+  // console.log('Relay environment:', relay.environment);
+  // console.log('Relay schema:', schema);
+  // const environment = {networkLayer: 'fake network layer', store: 'fake Relay store'};
   const PeriqlesForm = periqlesFormWrapper(schema, relay.environment);
 
   return (
@@ -78,7 +114,7 @@ const TodoApp = ({relay, user}: Props) => {
         <TodoList user={user} />
         {hasTodos && <TodoListFooter user={user} />}
       </section>
-      <PeriqlesForm mutation={mutation} specifications={specifications} />
+      <PeriqlesForm mutationName={mutation} mutationGQL={mutationGQL} specifications={specifications} args={[{name: 'clientMutationId', value:'0000'}, {name: 'userId', value: 'me'}]} />
       <footer className="info">
         <p>Double-click to edit a todo</p>
 

--- a/todo/js/components/TodoApp.js
+++ b/todo/js/components/TodoApp.js
@@ -17,10 +17,10 @@ import TodoTextInput from './TodoTextInput';
 
 import React from 'react';
 import {createFragmentContainer, commitMutation, graphql} from 'react-relay';
-// import {PeriqlesForm} from '../../../index.js';
+import {PeriqlesForm} from '../../../index.js';
 // import PeriqlesForm from './PeriqlesForm.js';
-import periqlesFormWrapper from './PeriqlesForm.js';
-import schema from './schema.js';
+// import periqlesFormWrapper from './PeriqlesForm.js';
+// import schema from './schema.js';
 import type {RelayProp} from 'react-relay';
 import type {TodoApp_user} from 'relay/TodoApp_user.graphql';
 
@@ -38,65 +38,46 @@ const TodoApp = ({relay, user}: Props) => {
   const hasTodos = user.totalCount > 0;
 
   // mock props for PeriqlesForm
-  const mutation = 'AddTodo';
-  const specifications = {
-    fields: {
-        name: {
-            label: "Name",
-            element: "text",
-        },
-        gender: {
-            label: "Gender",
-            element: "radio",
-            options: [
-              {label: "male", value: "m"},
-              {label:"female", value: "f"},
-              {label: "non-binary", value: "x"},
-            ],
-        }
-    },
-  };
+  // const mutation = 'AddTodo';
+  // const specifications = {
+  //   fields: {
+  //       name: {
+  //           label: "Name",
+  //           element: "text",
+  //       },
+  //       gender: {
+  //           label: "Gender",
+  //           element: "radio",
+  //           options: [
+  //             {label: "male", value: "m"},
+  //             {label:"female", value: "f"},
+  //             {label: "non-binary", value: "x"},
+  //           ],
+  //       }
+  //   },
+  // };
 
-  const mutationGQL = graphql`
-  mutation AddTodoMutation($input: AddTodoInput!) {
-    addTodo(input: $input) {
-      todoEdge {
-        __typename
-        cursor
-        node {
-          complete
-          id
-          text
-        }
-      }
-      user {
-        id
-        totalCount
-      }
-    }
-  }`;
-
-  const input = {
-    text: 'Race Usain Bolt',
-    clientMutationId:'0000',
-    userId: 'me',
-  };
-  const variables = {
-    input,
-  };
-
-  // commitMutation(relay.environment, {
-  //   mutationGQL,
-  //   variables,
-  //   onCompleted: (response, errors) => console.log('Server response to mutation:', response, errors),
-  //   onError: (err) => console.error('Problem committing mutation:', err),
-  // });   
+  // const mutationGQL = graphql`
+  // mutation AddTodoMutation($input: AddTodoInput!) {
+  //   addTodo(input: $input) {
+  //     todoEdge {
+  //       __typename
+  //       cursor
+  //       node {
+  //         complete
+  //         id
+  //         text
+  //       }
+  //     }
+  //     user {
+  //       id
+  //       totalCount
+  //     }
+  //   }
+  // }`;
 
   // mock making closure
-  // console.log('Relay environment:', relay.environment);
-  // console.log('Relay schema:', schema);
-  // const environment = {networkLayer: 'fake network layer', store: 'fake Relay store'};
-  const PeriqlesForm = periqlesFormWrapper(schema, relay.environment);
+  // const PeriqlesForm = periqlesFormWrapper(schema, relay.environment);
 
   return (
     <div>
@@ -114,7 +95,26 @@ const TodoApp = ({relay, user}: Props) => {
         <TodoList user={user} />
         {hasTodos && <TodoListFooter user={user} />}
       </section>
-      <PeriqlesForm mutationName={mutation} mutationGQL={mutationGQL} specifications={specifications} args={[{name: 'clientMutationId', value:'0000'}, {name: 'userId', value: 'me'}]} />
+      <PeriqlesForm mutationName={'AddTodo'} 
+                    mutationGQL={graphql`
+                    mutation AddTodoMutation($input: AddTodoInput!) {
+                      addTodo(input: $input) {
+                        todoEdge {
+                          __typename
+                          cursor
+                          node {
+                            complete
+                            id
+                            text
+                          }
+                        }
+                        user {
+                          id
+                          totalCount
+                        }
+                      }
+                    }`}  
+                    args={[{name: 'clientMutationId', value:'0000'}, {name: 'userId', value: 'me'}]} />
       <footer className="info">
         <p>Double-click to edit a todo</p>
 

--- a/todo/js/components/schema.js
+++ b/todo/js/components/schema.js
@@ -1137,6 +1137,4 @@ typesArray.forEach(type => {
   schema[type.name] = type;
 });
 
-export default {schema};
-
-/*------------------------------------------------------------------*/
+export default schema;

--- a/todo/js/components/schema.js
+++ b/todo/js/components/schema.js
@@ -1,0 +1,1142 @@
+const typesArray = [
+  {
+      "name": "Query",
+      "fields": [
+          {
+              "name": "user",
+              "type": {
+                  "name": "User",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "node",
+              "type": {
+                  "name": "Node",
+                  "kind": "INTERFACE",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "User",
+      "fields": [
+          {
+              "name": "id",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "ID",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "userId",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "String",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "todos",
+              "type": {
+                  "name": "TodoConnection",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "totalCount",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "Int",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "completedCount",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "Int",
+                      "kind": "SCALAR"
+                  }
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "Node",
+      "fields": [
+          {
+              "name": "id",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "ID",
+                      "kind": "SCALAR"
+                  }
+              }
+          }
+      ],
+      "kind": "INTERFACE",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "ID",
+      "fields": null,
+      "kind": "SCALAR",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "String",
+      "fields": null,
+      "kind": "SCALAR",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "TodoConnection",
+      "fields": [
+          {
+              "name": "pageInfo",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "PageInfo",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "edges",
+              "type": {
+                  "name": null,
+                  "kind": "LIST",
+                  "ofType": {
+                      "name": "TodoEdge",
+                      "kind": "OBJECT"
+                  }
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "PageInfo",
+      "fields": [
+          {
+              "name": "hasNextPage",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "Boolean",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "hasPreviousPage",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "Boolean",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "startCursor",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "endCursor",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "Boolean",
+      "fields": null,
+      "kind": "SCALAR",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "TodoEdge",
+      "fields": [
+          {
+              "name": "node",
+              "type": {
+                  "name": "Todo",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "cursor",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "String",
+                      "kind": "SCALAR"
+                  }
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "Todo",
+      "fields": [
+          {
+              "name": "id",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "ID",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "text",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "String",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "complete",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "Boolean",
+                      "kind": "SCALAR"
+                  }
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "Int",
+      "fields": null,
+      "kind": "SCALAR",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "Mutation",
+      "fields": [
+          {
+              "name": "addTodo",
+              "type": {
+                  "name": "AddTodoPayload",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "changeTodoStatus",
+              "type": {
+                  "name": "ChangeTodoStatusPayload",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "markAllTodos",
+              "type": {
+                  "name": "MarkAllTodosPayload",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "removeCompletedTodos",
+              "type": {
+                  "name": "RemoveCompletedTodosPayload",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "removeTodo",
+              "type": {
+                  "name": "RemoveTodoPayload",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "renameTodo",
+              "type": {
+                  "name": "RenameTodoPayload",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "AddTodoPayload",
+      "fields": [
+          {
+              "name": "todoEdge",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "TodoEdge",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "user",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "User",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "AddTodoInput",
+      "fields": null,
+      "kind": "INPUT_OBJECT",
+      "inputFields": [
+          {
+              "name": "text",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "userId",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String"
+              }
+          }
+      ],
+      "ofType": null
+  },
+  {
+      "name": "ChangeTodoStatusPayload",
+      "fields": [
+          {
+              "name": "todo",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "Todo",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "user",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "User",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "ChangeTodoStatusInput",
+      "fields": null,
+      "kind": "INPUT_OBJECT",
+      "inputFields": [
+          {
+              "name": "complete",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "id",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "userId",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String"
+              }
+          }
+      ],
+      "ofType": null
+  },
+  {
+      "name": "MarkAllTodosPayload",
+      "fields": [
+          {
+              "name": "changedTodos",
+              "type": {
+                  "name": null,
+                  "kind": "LIST",
+                  "ofType": {
+                      "name": null,
+                      "kind": "NON_NULL"
+                  }
+              }
+          },
+          {
+              "name": "user",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "User",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "MarkAllTodosInput",
+      "fields": null,
+      "kind": "INPUT_OBJECT",
+      "inputFields": [
+          {
+              "name": "complete",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "userId",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String"
+              }
+          }
+      ],
+      "ofType": null
+  },
+  {
+      "name": "RemoveCompletedTodosPayload",
+      "fields": [
+          {
+              "name": "deletedTodoIds",
+              "type": {
+                  "name": null,
+                  "kind": "LIST",
+                  "ofType": {
+                      "name": null,
+                      "kind": "NON_NULL"
+                  }
+              }
+          },
+          {
+              "name": "user",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "User",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "RemoveCompletedTodosInput",
+      "fields": null,
+      "kind": "INPUT_OBJECT",
+      "inputFields": [
+          {
+              "name": "userId",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String"
+              }
+          }
+      ],
+      "ofType": null
+  },
+  {
+      "name": "RemoveTodoPayload",
+      "fields": [
+          {
+              "name": "deletedTodoId",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "ID",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "user",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "User",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "RemoveTodoInput",
+      "fields": null,
+      "kind": "INPUT_OBJECT",
+      "inputFields": [
+          {
+              "name": "id",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "userId",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String"
+              }
+          }
+      ],
+      "ofType": null
+  },
+  {
+      "name": "RenameTodoPayload",
+      "fields": [
+          {
+              "name": "todo",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "Todo",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "RenameTodoInput",
+      "fields": null,
+      "kind": "INPUT_OBJECT",
+      "inputFields": [
+          {
+              "name": "id",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "text",
+              "type": {
+                  "name": null
+              }
+          },
+          {
+              "name": "clientMutationId",
+              "type": {
+                  "name": "String"
+              }
+          }
+      ],
+      "ofType": null
+  },
+  {
+      "name": "__Schema",
+      "fields": [
+          {
+              "name": "description",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "types",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": null,
+                      "kind": "LIST"
+                  }
+              }
+          },
+          {
+              "name": "queryType",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "__Type",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "mutationType",
+              "type": {
+                  "name": "__Type",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "subscriptionType",
+              "type": {
+                  "name": "__Type",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "directives",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": null,
+                      "kind": "LIST"
+                  }
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "__Type",
+      "fields": [
+          {
+              "name": "kind",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "__TypeKind",
+                      "kind": "ENUM"
+                  }
+              }
+          },
+          {
+              "name": "name",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "description",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "specifiedByUrl",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "fields",
+              "type": {
+                  "name": null,
+                  "kind": "LIST",
+                  "ofType": {
+                      "name": null,
+                      "kind": "NON_NULL"
+                  }
+              }
+          },
+          {
+              "name": "interfaces",
+              "type": {
+                  "name": null,
+                  "kind": "LIST",
+                  "ofType": {
+                      "name": null,
+                      "kind": "NON_NULL"
+                  }
+              }
+          },
+          {
+              "name": "possibleTypes",
+              "type": {
+                  "name": null,
+                  "kind": "LIST",
+                  "ofType": {
+                      "name": null,
+                      "kind": "NON_NULL"
+                  }
+              }
+          },
+          {
+              "name": "enumValues",
+              "type": {
+                  "name": null,
+                  "kind": "LIST",
+                  "ofType": {
+                      "name": null,
+                      "kind": "NON_NULL"
+                  }
+              }
+          },
+          {
+              "name": "inputFields",
+              "type": {
+                  "name": null,
+                  "kind": "LIST",
+                  "ofType": {
+                      "name": null,
+                      "kind": "NON_NULL"
+                  }
+              }
+          },
+          {
+              "name": "ofType",
+              "type": {
+                  "name": "__Type",
+                  "kind": "OBJECT",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "__TypeKind",
+      "fields": null,
+      "kind": "ENUM",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "__Field",
+      "fields": [
+          {
+              "name": "name",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "String",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "description",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "args",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": null,
+                      "kind": "LIST"
+                  }
+              }
+          },
+          {
+              "name": "type",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "__Type",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "isDeprecated",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "Boolean",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "deprecationReason",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "__InputValue",
+      "fields": [
+          {
+              "name": "name",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "String",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "description",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "type",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "__Type",
+                      "kind": "OBJECT"
+                  }
+              }
+          },
+          {
+              "name": "defaultValue",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "isDeprecated",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "Boolean",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "deprecationReason",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "__EnumValue",
+      "fields": [
+          {
+              "name": "name",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "String",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "description",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "isDeprecated",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "Boolean",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "deprecationReason",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "__Directive",
+      "fields": [
+          {
+              "name": "name",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "String",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "description",
+              "type": {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "ofType": null
+              }
+          },
+          {
+              "name": "isRepeatable",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": "Boolean",
+                      "kind": "SCALAR"
+                  }
+              }
+          },
+          {
+              "name": "locations",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": null,
+                      "kind": "LIST"
+                  }
+              }
+          },
+          {
+              "name": "args",
+              "type": {
+                  "name": null,
+                  "kind": "NON_NULL",
+                  "ofType": {
+                      "name": null,
+                      "kind": "LIST"
+                  }
+              }
+          }
+      ],
+      "kind": "OBJECT",
+      "inputFields": null,
+      "ofType": null
+  },
+  {
+      "name": "__DirectiveLocation",
+      "fields": null,
+      "kind": "ENUM",
+      "inputFields": null,
+      "ofType": null
+  }
+];
+
+
+
+// convert schema from array to object for faster lookup times within PeriqlesForm
+const schema = {};
+typesArray.forEach(type => {
+  schema[type.name] = type;
+});
+
+export default {schema};
+
+/*------------------------------------------------------------------*/

--- a/todo/js/mutations/AddUserMutation.js
+++ b/todo/js/mutations/AddUserMutation.js
@@ -1,94 +1,94 @@
-import {
-  commitMutation,
-  graphql,
-  type Disposable,
-  type Environment,
-  type RecordProxy,
-  type RecordSourceSelectorProxy,
-} from 'react-relay';
+// import {
+//   commitMutation,
+//   graphql,
+//   type Disposable,
+//   type Environment,
+//   type RecordProxy,
+//   type RecordSourceSelectorProxy,
+// } from 'react-relay';
 
-import {ConnectionHandler} from 'relay-runtime';
-// import type {TodoApp_user} from 'relay/TodoApp_user.graphql';
-import type {AddUserInput} from 'relay/AddUserMutation.graphql';  // TODO in typescript?
+// import {ConnectionHandler} from 'relay-runtime';
+// // import type {TodoApp_user} from 'relay/TodoApp_user.graphql';
+// import type {AddUserInput} from 'relay/AddUserMutation.graphql';  // TODO in typescript?
 
-// TODO: consult with Ian and Joe about fields and types to return from AddUser mutation
-const mutation = graphql`
-  mutation AddUserMutation($input: AddUserInput!) {
-    addUser(input: $input) {
-      user {
-        node {
-          id
-        }
-        username
-        password
-        email
-        gender
-        pizzaTopping
-        age
-      }
-    }
-  }
-`;
+// // TODO: consult with Ian and Joe about fields and types to return from AddUser mutation
+// const mutation = graphql`
+//   mutation AddUserMutation($input: AddUserInput!) {
+//     addUser(input: $input) {
+//       user {
+//         node {
+//           id
+//         }
+//         username
+//         password
+//         email
+//         gender
+//         pizzaTopping
+//         age
+//       }
+//     }
+//   }
+// `;
 
-export default {mutation: mutationQL};
-// Everything below is non-essential; at minimum only need to export the mutation query
+// export default {mutation: mutationQL};
+// // Everything below is non-essential; at minimum only need to export the mutation query
 
-// TODO: What to replace this updater fn with?
-function sharedUpdater(
-  store: RecordSourceSelectorProxy,
-  user
-) {
-  const userProxy = store.get(user.id);  
-  // const conn = ConnectionHandler.getConnection(userProxy, 'TodoList_todos');
-  // ConnectionHandler.insertEdgeAfter(conn, newEdge);
-}
+// // TODO: What to replace this updater fn with?
+// function sharedUpdater(
+//   store: RecordSourceSelectorProxy,
+//   user
+// ) {
+//   const userProxy = store.get(user.id);  
+//   // const conn = ConnectionHandler.getConnection(userProxy, 'TodoList_todos');
+//   // ConnectionHandler.insertEdgeAfter(conn, newEdge);
+// }
 
-let tempID = 0;
+// let tempID = 0;
 
-// can leave this out
-function commit(
-  environment: Environment,
-  username,
-  password,
-  email,
-  gender,
-  pizzaTopping,
-  age,
-): Disposable {
+// // can leave this out
+// function commit(
+//   environment: Environment,
+//   username,
+//   password,
+//   email,
+//   gender,
+//   pizzaTopping,
+//   age,
+// ): Disposable {
 
-  const input: AddUserInput = {
-    // add input values listed above to an input object
-    username,
-    password,
-    email,
-    gender,
-    pizzaTopping,
-    age,
-    clientMutationId: `${tempID++}`,    // why is this unique?
-  };
+//   const input: AddUserInput = {
+//     // add input values listed above to an input object
+//     username,
+//     password,
+//     email,
+//     gender,
+//     pizzaTopping,
+//     age,
+//     clientMutationId: `${tempID++}`,    // why is this unique?
+//   };
 
-  return commitMutation(environment, {
-    mutation,
-    variables: {
-      input,
-    },
-    updater: (store: RecordSourceSelectorProxy) => {      // TODO: needed? is there a default to fall back to if I leave it off?
-      const payload = store.getRootField('addUser');      // TODO
-      // const newEdge = payload.getLinkedRecord('todoEdge');   // TODO: what should this be?
-      sharedUpdater(store, user);
-    },
-    optimisticUpdater: (store: RecordSourceSelectorProxy) => {    // TODO: needed?
-      // const id = 'client:newTodo:' + tempID++;     // TODO: make a new, unique mutation id
-      const user = store.create(id, 'User');    // create(idForNewData, typeNameFromSchema) --> RecordProxy
-      user.setValue(username, 'username');      // setValue(value, fieldName)
-      user.setValue(password, 'password');
-      user.setValue(email, 'email');
-      user.setValue(gender, 'gender');
-      user.setValue(pizzaTopping, 'pizzaTopping');
-      user.setValue(age, 'age');
-      sharedUpdater(store, user);
-    },
-  });
-}
+//   return commitMutation(environment, {
+//     mutation,
+//     variables: {
+//       input,
+//     },
+//     updater: (store: RecordSourceSelectorProxy) => {      // TODO: needed? is there a default to fall back to if I leave it off?
+//       const payload = store.getRootField('addUser');      // TODO
+//       // const newEdge = payload.getLinkedRecord('todoEdge');   // TODO: what should this be?
+//       sharedUpdater(store, user);
+//     },
+//     optimisticUpdater: (store: RecordSourceSelectorProxy) => {    // TODO: needed?
+//       // const id = 'client:newTodo:' + tempID++;     // TODO: make a new, unique mutation id
+//       const user = store.create(id, 'User');    // create(idForNewData, typeNameFromSchema) --> RecordProxy
+//       user.setValue(username, 'username');      // setValue(value, fieldName)
+//       user.setValue(password, 'password');
+//       user.setValue(email, 'email');
+//       user.setValue(gender, 'gender');
+//       user.setValue(pizzaTopping, 'pizzaTopping');
+//       user.setValue(age, 'age');
+//       sharedUpdater(store, user);
+//     },
+//   });
+// }
 
-export {commit};
+// export {commit};


### PR DESCRIPTION
PeriqlesForm can now parse a schema, correctly identify the scalar data types of each mutation input field, and assign a default OR specified HTML element to each input field. This is achieved using a set of helper functions:

- `fieldsArrayGenerator`: Given the name of a mutation exactly as it appears on a GraphQL schema plus an array of objects representing input fields to be excluded from the form, generates an array of objects containing the names and scalar data types of every remaining input field needed to complete the mutation.
    - Our current solution to this problem involves 3 nested for-loops in the worst-case scenario, and the function must execute every time a PF re-renders — and it re-renders the whole form with every onChange! It'd be really great to optimize this: We could bring that time complexity down, invoke it once on initial page load and cache the results, and/or look into the re-rendering behavior of PF.
    - We sketched out some initial ideas for handling enumerated fields, but haven't figured it out yet. The schema example we were working off of didn't contain any enumerated fields, so this part will be easier once we can see how enums are represented on the schema.
- `generateDefaultElement`: a switch case that translates an input field into 1 of 3 default input elements. Supports enumerated fields as dropdowns.
- `generateSpecifiedElement`: a switch case that translates an input field into an input element based on instructions provided in the `fields` array on the `specifications` prop. Supports enumerated fields as checkboxes, radio buttons, or dropdowns.
- `formBuilder`: Given the array of field objects returned out of `fieldsArrayGenerator`, builds an array of HTML elements, routing each field object through `generateDefaultElement` or `generateSpecifiedElement` based on whether it is included in `specifications.fields`.

The local state of the form is managed using the `useState` hook and by attaching a piece of state to the "value" attribute on each HTML element plus a change handler to set state. 

When it is time to commit the mutation, the submit handler compiles form state into an input object that is appropriately shaped according to our best understanding of the Relay docs entry re: `commitMutation`. The handler invokes `commitMutation` with the following args: 

- the environment provided to PeriqlesForm by periqlesFormWrapper; 
- a config object containing: 
    - a `mutation` property containing the mutation request (which must be passed into PF's props as a GraphQLTaggedNode, instantiated using the `graphql` template tag imported from `react-relay`)
    - a `variables` object, containing the input object compiled from form state as a property  
        -  _Note: for now, we're assuming that the clientMutationId input vairable that's required for every mutation will be passed in in the args prop. In the future we might generate clientMutationIds within PF. _
    - two callbacks, `onCompleted` and `onError`, which console-log basic status messages in the client

**Hard-won tip:** The names of the parameters to be included in the config object aren't flexible! For example, passing in `mutation` as "mutationGQL" will throw a null pointer error. 😠  This syntax works, however: `mutation: mutationGQL`.

The docs show that `commitMutation` can also take optional "updater" callbacks, including an `optimisticUpdater`. It looks like if you wanted a mutation to trigger a component to re-render with the submitted form data, these callbacks are how you would achieve it. We might consider allowing the dev to pass in a set of updater callbacks to PF as another prop.